### PR TITLE
Fix Spanish accents in prompts and translations

### DIFF
--- a/app/common/assistant_prompt.py
+++ b/app/common/assistant_prompt.py
@@ -2,28 +2,28 @@ from langchain_core.prompts import ChatPromptTemplate
 
 ES_PROMPT = """
 # Rol
-Sos la secretaria de PBC; tu nombre es Bastet y tu objetivo es comunicar la informacion de proyectos y reuniones al equipo de forma clara, concisa y profesional.
+Eres la asistente de PBC; te llamas Bastet y tu objetivo es comunicar la información de proyectos y reuniones al equipo de forma clara, concisa y profesional.
 
 # Tarea
-Responder de manera amigable y util cada consulta del equipo. Si la consulta es un saludo simple (por ejemplo, "Hola" o "Buenos dias"), responde cordialmente y ofrece ayuda. Si la consulta necesita informacion especifica, usa el contexto disponible para dar una respuesta precisa.
+Responde de manera amigable y útil cada consulta del equipo. Si la consulta es un saludo simple (por ejemplo, "Hola" o "Buenos días"), responde cordialmente y ofrece ayuda. Si la consulta necesita información específica, usa el contexto disponible para dar una respuesta precisa.
 
 Question: {question}
 Context: {context}
 
-# Instrucciones especificas
+# Instrucciones específicas
 - Si es un saludo general, responde con calidez y ofrece asistencia adicional.
-- Cuando haya contexto relevante, integralo en la respuesta de forma sintetica.
-- Si no hay contexto suficiente para una pregunta puntual, explica que necesitas mas informacion o documentos.
-- Mantene un tono profesional pero amable.
-- Responde siempre en espanol latino natural.
+- Cuando haya contexto relevante, intégralo en la respuesta de forma sintética.
+- Si no hay contexto suficiente para una pregunta puntual, explica que necesitas más información o documentos.
+- Mantén un tono profesional pero amable.
+- Responde siempre en español latino natural.
 
 # Contexto
-PBC es una consultora que ofrece servicios de Ingenieria de Software e Inteligencia Artificial en Latinoamerica para ayudar a las empresas a ser data driven. Los productos principales son: Cubo de Datos, AVI (Asistente Virtual Inteligente) y la Plataforma Business Intelligence PBC.
+PBC es una consultora que ofrece servicios de Ingeniería de Software e Inteligencia Artificial en Latinoamérica para ayudar a las empresas a ser data driven. Los productos principales son: Cubo de Datos, AVI (Asistente Virtual Inteligente) y la Plataforma Business Intelligence PBC.
 
 # Notas
-- Se concisa, especifica y detallada sin agregar informacion innecesaria.
-- No describas productos o proyectos salvo que esten relacionados a la consulta.
-- Enfocate en responder lo que se te pregunto.
+- Sé concisa, específica y detallada sin agregar información innecesaria.
+- No describas productos o proyectos salvo que estén relacionados con la consulta.
+- Enfócate en responder lo que se te preguntó.
 """
 
 EN_PROMPT = """

--- a/app/common/translations.py
+++ b/app/common/translations.py
@@ -11,8 +11,8 @@ translations = {
 
         # Inicio.py
         "chat_placeholder": "Escribe tu mensaje :)",
-        "empty_message_error": "Por favor, escribe un mensaje valido.",
-        "long_message_error": "El mensaje es demasiado largo. Por favor, hazlo mas conciso (maximo 1000 caracteres).",
+        "empty_message_error": "Por favor, escribe un mensaje válido.",
+        "long_message_error": "El mensaje es demasiado largo. Por favor, hazlo más conciso (máximo 1000 caracteres).",
         "processing_message": "Procesando tu consulta...",
 
         # Archivos.py
@@ -20,27 +20,27 @@ translations = {
         "upload_file": "Cargar archivo",
         "add_to_knowledge_base": "Agregar archivo a la base de conocimiento",
         "processing_file": "Procesando archivo: {file_name}",
-        "validation_error": "Error de validacion: {message}",
-        "upload_warning": "Por favor carga al menos un archivo antes de agregarlo a la base de conocimiento.",
+        "validation_error": "Error de validación: {message}",
+        "upload_warning": "Por favor, carga al menos un archivo antes de agregarlo a la base de conocimiento.",
         "files_in_knowledge_base": "Archivos en la base de conocimiento:",
         "delete_file": "Eliminar archivo",
         "delete_from_knowledge_base": "Eliminar archivo de la base de conocimiento",
-        "file_deleted": "Archivo eliminado con exito",
-        "delete_error": "Ocurrio un error al eliminar el archivo: {error}",
+        "file_deleted": "Archivo eliminado con éxito",
+        "delete_error": "Ocurrió un error al eliminar el archivo: {error}",
         "one_file_at_a_time": "Solo se permite eliminar un archivo a la vez.",
 
         # Language selector
         "language_selector": "Idioma",
-        "language_es": "Espanol",
-        "language_en": "Ingles",
+        "language_es": "Español",
+        "language_en": "Inglés",
 
         # RAG responses
-        "invalid_query": "Por favor, proporciona una consulta valida.",
-        "long_query": "La consulta es demasiado larga. Por favor, hazla mas concisa.",
-        "greeting_response": "Hola! Soy Bastet, tu asistente virtual de PBC. Estoy aqui para ayudarte con informacion sobre nuestros proyectos, productos y servicios. En que puedo asistirte hoy?",
-        "no_documents": "Hola, soy Bastet de PBC. Actualmente no tengo documentos en mi base de conocimiento. Por favor, sube algunos documentos en la seccion 'Archivos' para que pueda ayudarte con informacion especifica. Mientras tanto, puedo contarte que PBC ofrece servicios de Ingenieria de Software e Inteligencia Artificial.",
-        "no_context": "No se encontro informacion especifica en la base de conocimiento.",
-        "processing_error": "Lo siento, ocurrio un error al procesar tu consulta. Por favor, intenta nuevamente o contacta al administrador si el problema persiste."
+        "invalid_query": "Por favor, proporciona una consulta válida.",
+        "long_query": "La consulta es demasiado larga. Por favor, hazla más concisa.",
+        "greeting_response": "¡Hola! Soy Bastet, tu asistente virtual de PBC. Estoy aquí para ayudarte con información sobre nuestros proyectos, productos y servicios. ¿En qué puedo asistirte hoy?",
+        "no_documents": "Hola, soy Bastet de PBC. Actualmente no tengo documentos en mi base de conocimiento. Por favor, sube algunos documentos en la sección 'Archivos' para que pueda ayudarte con información específica. Mientras tanto, puedo contarte que PBC ofrece servicios de Ingeniería de Software e Inteligencia Artificial.",
+        "no_context": "No se encontró información específica en la base de conocimiento.",
+        "processing_error": "Lo siento, ocurrió un error al procesar tu consulta. Por favor, intenta nuevamente o contacta al administrador si el problema persiste."
     },
 
     "en": {  # English


### PR DESCRIPTION
## Summary
- update the Spanish translation catalog so every string uses the correct accents and characters
- polish the assistant prompt in Spanish with proper accent marks and natural phrasing

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pkg_resources')*

------
https://chatgpt.com/codex/tasks/task_e_68d014b103a8832095b072db05f793f0