### PR TITLE
Load i18n languages from config file

### DIFF
--- a/app/Inicio.py
+++ b/app/Inicio.py
@@ -36,6 +36,17 @@ except ImportError:
     import sys
     sys.exit(1)
 
+# Helper to provide readable labels for the language selector
+def _format_language_label(language_code: str, active_language: str, default_language: str) -> str:
+    label = get_text(f"language_{language_code}", active_language)
+    if label == f"language_{language_code}":
+        fallback_label = get_text(f"language_{language_code}", default_language)
+        if fallback_label == f"language_{language_code}":
+            return language_code.upper()
+        return fallback_label
+    return label
+
+
 # Initialize language in session state if not already set
 default_language = get_default_language()
 available_languages = get_supported_languages()
@@ -59,7 +70,7 @@ with st.sidebar:
     selected_language = st.selectbox(
         get_text("language_selector", st.session_state.language),
         options=available_languages,
-        format_func=lambda x: get_text(f"language_{x}", st.session_state.language),
+        format_func=lambda code: _format_language_label(code, st.session_state.language, default_language),
         index=available_languages.index(st.session_state.language)
     )
     

--- a/app/common/config.py
+++ b/app/common/config.py
@@ -1,23 +1,93 @@
 """Application configuration helpers."""
 from __future__ import annotations
 
-from typing import List
+import threading
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Dict, List
 
-# Default language for the application
-DEFAULT_LANGUAGE: str = "es"
+import yaml
 
-# Ordered list of supported language codes
-_SUPPORTED_LANGUAGES: List[str] = [
-    "es",
-    "en",
-]
+_DEFAULT_CONFIG: Dict[str, Any] = {
+    "default_language": "es",
+    "supported_languages": ["es", "en"],
+}
+
+_CONFIG_LOCK = threading.Lock()
+_CACHED_CONFIG: Dict[str, Any] | None = None
+
+
+def _config_path() -> Path:
+    """Return the path to the YAML configuration file."""
+
+    return Path(__file__).resolve().with_suffix(".yaml")
+
+
+def _load_config() -> Dict[str, Any]:
+    """Load configuration data from disk and cache the result."""
+
+    global _CACHED_CONFIG
+    with _CONFIG_LOCK:
+        if _CACHED_CONFIG is not None:
+            return _CACHED_CONFIG
+
+        path = _config_path()
+        data: Dict[str, Any] = {}
+
+        if path.exists():
+            with path.open("r", encoding="utf-8") as handle:
+                loaded = yaml.safe_load(handle) or {}
+            if not isinstance(loaded, Mapping):
+                raise ValueError("Configuration file must contain a mapping at the top level.")
+            data = dict(loaded)
+
+        config: Dict[str, Any] = {**_DEFAULT_CONFIG, **data}
+
+        default_language = config.get("default_language")
+        if not isinstance(default_language, str) or not default_language.strip():
+            default_language = _DEFAULT_CONFIG["default_language"]
+        default_language = default_language.strip()
+
+        supported_languages_value = config.get("supported_languages")
+        supported_languages: List[str] = []
+        if isinstance(supported_languages_value, (list, tuple)):
+            for language in supported_languages_value:
+                if not isinstance(language, str):
+                    continue
+                cleaned = language.strip()
+                if cleaned and cleaned not in supported_languages:
+                    supported_languages.append(cleaned)
+
+        if not supported_languages:
+            supported_languages = list(_DEFAULT_CONFIG["supported_languages"])
+
+        if default_language not in supported_languages:
+            supported_languages.insert(0, default_language)
+
+        _CACHED_CONFIG = {
+            "default_language": default_language,
+            "supported_languages": supported_languages,
+        }
+
+        return _CACHED_CONFIG
+
+
+def reload_config() -> None:
+    """Clear the cached configuration data."""
+
+    global _CACHED_CONFIG
+    with _CONFIG_LOCK:
+        _CACHED_CONFIG = None
 
 
 def get_default_language() -> str:
     """Return the default language for the application."""
-    return DEFAULT_LANGUAGE
+
+    return str(_load_config()["default_language"])
 
 
 def get_supported_languages() -> List[str]:
     """Return the list of supported language codes."""
-    return list(_SUPPORTED_LANGUAGES)
+
+    languages = _load_config()["supported_languages"]
+    return list(languages)

--- a/app/common/config.yaml
+++ b/app/common/config.yaml
@@ -1,0 +1,4 @@
+default_language: es
+supported_languages:
+  - es
+  - en

--- a/app/common/translations.py
+++ b/app/common/translations.py
@@ -1,114 +1,25 @@
 """Translation utilities for the Anclora AI RAG application."""
-
-from common.config import get_default_language, get_supported_languages
-
-# Dictionary of translations for different languages
-translations = {
-    "es": {  # Spanish (default)
-        # Common
-        "app_title": "Anclora AI RAG",
-
-        # Inicio.py
-        "chat_placeholder": "Escribe tu mensaje :)",
-        "empty_message_error": "Por favor, escribe un mensaje valido.",
-        "long_message_error": "El mensaje es demasiado largo. Por favor, hazlo mas conciso (maximo 1000 caracteres).",
-        "processing_message": "Procesando tu consulta...",
-
-        # Archivos.py
-        "files_title": "Archivos",
-        "upload_file": "Cargar archivo",
-        "add_to_knowledge_base": "Agregar archivo a la base de conocimiento",
-        "processing_file": "Procesando archivo: {file_name}",
-        "validation_error": "Error de validacion: {message}",
-        "upload_warning": "Por favor carga al menos un archivo antes de agregarlo a la base de conocimiento.",
-        "files_in_knowledge_base": "Archivos en la base de conocimiento:",
-        "delete_file": "Eliminar archivo",
-        "delete_from_knowledge_base": "Eliminar archivo de la base de conocimiento",
-        "file_deleted": "Archivo eliminado con exito",
-        "delete_error": "Ocurrio un error al eliminar el archivo: {error}",
-        "one_file_at_a_time": "Solo se permite eliminar un archivo a la vez.",
-
-        # Language selector
-        "language_selector": "Idioma",
-        "language_es": "Espanol",
-        "language_en": "Ingles",
-
-        # RAG responses
-        "invalid_query": "Por favor, proporciona una consulta valida.",
-        "long_query": "La consulta es demasiado larga. Por favor, hazla mas concisa.",
-        "greeting_response": "Hola! Soy Bastet, tu asistente virtual de PBC. Estoy aqui para ayudarte con informacion sobre nuestros proyectos, productos y servicios. En que puedo asistirte hoy?",
-        "no_documents": "Hola, soy Bastet de PBC. Actualmente no tengo documentos en mi base de conocimiento. Por favor, sube algunos documentos en la seccion 'Archivos' para que pueda ayudarte con informacion especifica. Mientras tanto, puedo contarte que PBC ofrece servicios de Ingenieria de Software e Inteligencia Artificial.",
-        "no_context": "No se encontro informacion especifica en la base de conocimiento.",
-        "processing_error": "Lo siento, ocurrio un error al procesar tu consulta. Por favor, intenta nuevamente o contacta al administrador si el problema persiste."
-    },
-
-    "en": {  # English
-        # Common
-        "app_title": "Anclora AI RAG",
-
-        # Inicio.py
-        "chat_placeholder": "Type your message :)",
-        "empty_message_error": "Please write a valid message.",
-        "long_message_error": "The message is too long. Please make it more concise (maximum 1000 characters).",
-        "processing_message": "Processing your query...",
-
-        # Archivos.py
-        "files_title": "Files",
-        "upload_file": "Upload file",
-        "add_to_knowledge_base": "Add file to knowledge base",
-        "processing_file": "Processing file: {file_name}",
-        "validation_error": "Validation error: {message}",
-        "upload_warning": "Please upload at least one file before adding it to the knowledge base.",
-        "files_in_knowledge_base": "Files in knowledge base:",
-        "delete_file": "Delete file",
-        "delete_from_knowledge_base": "Delete file from knowledge base",
-        "file_deleted": "File successfully deleted",
-        "delete_error": "An error occurred while deleting the file: {error}",
-        "one_file_at_a_time": "Only one file can be deleted at a time.",
-
-        # Language selector
-        "language_selector": "Language",
-        "language_es": "Spanish",
-        "language_en": "English",
-
-        # RAG responses
-        "invalid_query": "Please provide a valid query.",
-        "long_query": "The query is too long. Please make it more concise.",
-        "greeting_response": "Hello! I'm Bastet, your virtual assistant from PBC. I'm here to help you with information about our projects, products, and services. How can I assist you today?",
-        "no_documents": "Hi, I'm Bastet from PBC. I don't have any documents in my knowledge base yet. Please upload some documents in the 'Files' section so I can help you with specific information. In the meantime, I can share that PBC offers Software Engineering and Artificial Intelligence services.",
-        "no_context": "No specific information was found in the knowledge base.",
-        "processing_error": "Sorry, an error occurred while processing your query. Please try again or contact the administrator if the problem persists."
-    },
-}
-
-
-def get_text(key, lang=None, **kwargs):
-    """
-    Get the translated text for a given key and language.
-
 from __future__ import annotations
 
 import os
 import threading
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Dict, List, Tuple
 
 import yaml
 
-
-DEFAULT_LANGUAGE = "es"
-"""Language code used when the requested language is not available."""
+from .config import get_default_language, get_supported_languages
 
 TRANSLATIONS_DIR_ENV_VAR = "ANCLORA_I18N_DIR"
-"""Environment variable that overrides the default directory for translation files."""
+"""Environment variable used to override the translation directory."""
+
+_SUPPORTED_EXTENSIONS = (".yml", ".yaml")
 
 _CACHE_LOCK = threading.Lock()
 _CACHED_TRANSLATIONS: Dict[str, Dict[str, Any]] = {}
 _CACHED_SIGNATURE: Tuple[Tuple[str, float], ...] | None = None
 _CACHED_DIRECTORY: Path | None = None
-
-_SUPPORTED_EXTENSIONS = (".yml", ".yaml")
 
 
 def _resolve_translations_dir() -> Path:
@@ -120,29 +31,29 @@ def _resolve_translations_dir() -> Path:
     return Path(__file__).resolve().parent / "i18n"
 
 
-def _list_translation_files(directory: Path) -> Iterable[Path]:
-    """Yield translation files from ``directory`` that match supported extensions."""
+def _list_translation_files(directory: Path) -> List[Path]:
+    """Return a deterministic list of translation files in ``directory``."""
 
     if not directory.exists():
         return []
 
-    files: Dict[Path, Path] = {}
+    files: Dict[str, Path] = {}
     for extension in _SUPPORTED_EXTENSIONS:
         for candidate in directory.glob(f"*{extension}"):
             try:
                 resolved = candidate.resolve()
             except FileNotFoundError:
                 continue
-            if not resolved.is_file():
-                continue
-            files[resolved] = candidate
-    return sorted(files.values())
+            if resolved.is_file():
+                files[str(resolved)] = candidate
+
+    return [files[key] for key in sorted(files)]
 
 
 def _build_signature(files: Iterable[Path]) -> Tuple[Tuple[str, float], ...]:
     """Create a signature representing the state of the translation files."""
 
-    signature = []
+    signature: List[Tuple[str, float]] = []
     for file_path in files:
         try:
             mtime = file_path.stat().st_mtime
@@ -150,31 +61,10 @@ def _build_signature(files: Iterable[Path]) -> Tuple[Tuple[str, float], ...]:
             continue
         signature.append((str(file_path.resolve()), mtime))
     return tuple(sorted(signature))
-    
-    Returns:
-        str: The translated text
-    """
-    default_language = get_default_language()
-    supported_languages = get_supported_languages()
 
-    if not supported_languages:
-        supported_languages = [default_language]
 
-    if default_language not in translations:
-        translations.setdefault(default_language, {})
-
-    if lang is None or lang not in supported_languages:
-        lang = default_language
-
-    language_translations = translations.get(lang, {})
-    if not language_translations:
-        language_translations = translations.get(default_language, {})
-        lang = default_language
-
-    # Get the translation for the key, or fall back to the default language
-    text = language_translations.get(key)
-    if text is None:
-        text = translations.get(default_language, {}).get(key, key)
+def _load_translations_from_files(files: Iterable[Path]) -> Dict[str, Dict[str, Any]]:
+    """Load translation dictionaries from ``files``."""
 
     loaded: Dict[str, Dict[str, Any]] = {}
     for file_path in files:
@@ -182,11 +72,12 @@ def _build_signature(files: Iterable[Path]) -> Tuple[Tuple[str, float], ...]:
             with file_path.open("r", encoding="utf-8") as handle:
                 data = yaml.safe_load(handle) or {}
         except FileNotFoundError:
-            # File may have been removed between discovery and reading; skip it.
             continue
 
         if not isinstance(data, Mapping):
-            raise ValueError(f"Translation file {file_path} must contain a mapping at the top level.")
+            raise ValueError(
+                f"Translation file {file_path} must contain a mapping at the top level."
+            )
 
         loaded[file_path.stem] = {str(key): value for key, value in data.items()}
 
@@ -199,7 +90,7 @@ def _get_translations() -> Dict[str, Dict[str, Any]]:
     directory = _resolve_translations_dir()
 
     with _CACHE_LOCK:
-        files = list(_list_translation_files(directory))
+        files = _list_translation_files(directory)
         signature = _build_signature(files)
 
         global _CACHED_SIGNATURE, _CACHED_TRANSLATIONS, _CACHED_DIRECTORY
@@ -215,13 +106,26 @@ def _get_translations() -> Dict[str, Dict[str, Any]]:
         return _CACHED_TRANSLATIONS
 
 
-def get_text(key: str, lang: str = DEFAULT_LANGUAGE, **kwargs: Any) -> str:
+def get_text(key: str, lang: str | None = None, **kwargs: Any) -> str:
     """Return a localized string for ``key`` in the requested language."""
 
     translations = _get_translations()
+    default_language = get_default_language()
+    supported_languages = get_supported_languages()
 
-    language = lang if lang in translations else DEFAULT_LANGUAGE
-    text = translations.get(language, {}).get(key, key)
+    if not supported_languages:
+        supported_languages = [default_language]
+
+    if lang is None or lang not in supported_languages:
+        lang = default_language
+
+    language_code = lang if lang in translations else default_language
+    language_translations = translations.get(language_code, {})
+    default_translations = translations.get(default_language, {})
+
+    text = language_translations.get(key)
+    if text is None:
+        text = default_translations.get(key, key)
 
     if kwargs and isinstance(text, str):
         try:
@@ -234,11 +138,7 @@ def get_text(key: str, lang: str = DEFAULT_LANGUAGE, **kwargs: Any) -> str:
 
 
 def clear_translation_cache() -> None:
-    """Clear the in-memory cache of translations.
-
-    Primarily useful for testing. The next call to :func:`get_text` will reload
-    data from the YAML files.
-    """
+    """Clear the in-memory cache of translations."""
 
     with _CACHE_LOCK:
         global _CACHED_TRANSLATIONS, _CACHED_SIGNATURE, _CACHED_DIRECTORY

--- a/app/pages/Archivos.py
+++ b/app/pages/Archivos.py
@@ -38,6 +38,17 @@ except ImportError:
 
 hide_streamlit_style()
 
+# Helper to provide readable labels for the language selector
+def _format_language_label(language_code: str, active_language: str, default_language: str) -> str:
+    label = get_text(f"language_{language_code}", active_language)
+    if label == f"language_{language_code}":
+        fallback_label = get_text(f"language_{language_code}", default_language)
+        if fallback_label == f"language_{language_code}":
+            return language_code.upper()
+        return fallback_label
+    return label
+
+
 # Initialize language in session state if not already set
 default_language = get_default_language()
 available_languages = get_supported_languages()
@@ -61,7 +72,7 @@ with st.sidebar:
     selected_language = st.selectbox(
         get_text("language_selector", st.session_state.language),
         options=available_languages,
-        format_func=lambda x: get_text(f"language_{x}", st.session_state.language),
+        format_func=lambda code: _format_language_label(code, st.session_state.language, default_language),
         index=available_languages.index(st.session_state.language)
     )
     

--- a/tests/i18n/__init__.py
+++ b/tests/i18n/__init__.py
@@ -1,0 +1,1 @@
+"""Translation-related tests."""

--- a/tests/i18n/test_translations.py
+++ b/tests/i18n/test_translations.py
@@ -3,6 +3,16 @@
 import sys
 import types
 
+ACCENTED_CHARACTERS = set("áéíóúÁÉÍÓÚñÑ¡¿")
+
+
+def contains_accented_character(value: str) -> bool:
+    """Return True if the given value includes at least one accented character."""
+
+    return any(character in ACCENTED_CHARACTERS for character in value)
+
+
+# Ensure langchain_core.prompts is available before importing translations
 
 def _install_langchain_stub() -> None:
     """Provide a minimal stub for ``langchain_core.prompts`` if needed."""
@@ -30,19 +40,10 @@ _install_langchain_stub()
 
 from app.common import assistant_prompt, translations
 
-ACCENTED_CHARACTERS = set("áéíóúÁÉÍÓÚñÑ¡¿")
-
-
-def contains_accented_character(value: str) -> bool:
-    """Return True if the given value includes at least one accented character."""
-
-    return any(character in ACCENTED_CHARACTERS for character in value)
-
 
 def test_spanish_translations_have_accented_characters():
     """Critical Spanish translations must include accented characters."""
 
-    spanish = translations.translations["es"]
     keys_with_expected_accents = (
         "language_es",
         "empty_message_error",
@@ -52,7 +53,7 @@ def test_spanish_translations_have_accented_characters():
     )
 
     for key in keys_with_expected_accents:
-        value = spanish[key]
+        value = translations.get_text(key, "es")
         assert contains_accented_character(
             value
         ), f"El valor de '{key}' debe contener tildes o eñes."

--- a/tests/test_text_normalization.py
+++ b/tests/test_text_normalization.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from common.text_normalization import (
+from app.common.text_normalization import (
     NORMALIZATION_FORM,
     normalize_documents_nfc,
     normalize_to_nfc,

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,6 +1,7 @@
-from copy import deepcopy
 from pathlib import Path
 import sys
+
+import pytest
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
@@ -25,13 +26,27 @@ def test_unsupported_language_falls_back_to_default():
     assert translations_module.get_text("app_title", "fr") == default_text
 
 
-def test_missing_translation_key_falls_back_to_default():
-    default_language = get_default_language()
-    default_value = translations_module.translations[default_language]["files_title"]
+def test_missing_translation_key_falls_back_to_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    translations_module.clear_translation_cache()
 
-    backup = deepcopy(translations_module.translations["en"])
-    try:
-        translations_module.translations["en"].pop("files_title", None)
-        assert translations_module.get_text("files_title", "en") == default_value
-    finally:
-        translations_module.translations["en"] = backup
+    es_file = tmp_path / "es.yml"
+    es_file.write_text(
+        "app_title: \"Anclora AI RAG\"\nfiles_title: \"Archivos\"\n",
+        encoding="utf-8",
+    )
+
+    en_file = tmp_path / "en.yml"
+    en_file.write_text(
+        "app_title: \"Anclora AI RAG\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv(translations_module.TRANSLATIONS_DIR_ENV_VAR, str(tmp_path))
+    translations_module.clear_translation_cache()
+
+    default_language = get_default_language()
+    default_value = translations_module.get_text("files_title", default_language)
+
+    assert translations_module.get_text("files_title", "en") == default_value
+
+    translations_module.clear_translation_cache()


### PR DESCRIPTION
## Summary
- load the default and supported languages from a YAML configuration file and expose helpers that cache the parsed data
- harden the translation loader to rely on the configuration values and provide safe fallbacks when keys or whole locales are missing
- update the Streamlit pages to render language labels via the configuration-driven list and refresh the tests to cover the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d017fe8fb0832090f8683d5312d615