### PR TITLE
Add language detection helper and tests

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -29,3 +29,4 @@ sentence_transformers
 fastapi
 uvicorn[standard]
 python-multipart
+langdetect==1.0.9

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -6,3 +6,13 @@ Para garantizar resultados consistentes al indexar y consultar documentos en mú
 - **Consultas**: Las preguntas de los usuarios se normalizan con el mismo criterio antes de aplicar validaciones o enviarlas al motor de recuperación. Con ello aseguramos comparaciones consistentes, especialmente cuando se introducen caracteres combinados desde distintos teclados o sistemas operativos.
 
 Esta estrategia respeta las diferencias semánticas entre palabras acentuadas y no acentuadas (por ejemplo, `café` frente a `cafe`), al tiempo que evita que variaciones en la representación Unicode afecten la búsqueda o la generación de respuestas.
+
+## Detección de idioma en consultas
+
+Para seleccionar la plantilla de mensajes y las respuestas en el idioma correcto se utiliza la librería [``langdetect``](https://pypi.org/project/langdetect/). Antes de invocar el modelo se analiza el texto original (tras normalizarlo a NFC) con la función `detect_language`, que devuelve códigos `es` o `en`.
+
+- Cuando el usuario no especifica idioma, `response()` emplea el resultado de `detect_language` como valor por defecto.
+- La detección se refuerza con una heurística ligera que prioriza español cuando la cadena contiene tildes (`á`, `é`, `í`, etc.), signos de interrogación/exclamación invertidos (`¿`, `¡`) o saludos frecuentes (`hola`, `gracias`, `buenos/buenas`). Esto evita que los acentos se pierdan al normalizar y reduce falsos positivos hacia inglés en frases mixtas.
+- Si el detector devuelve un idioma no soportado o no se puede determinar con confianza, el sistema cae de nuevo a español para mantener la compatibilidad con el comportamiento anterior.
+
+De esta forma se mantienen las tildes originales del usuario y se ofrece una experiencia bilingüe más consistente sin introducir dependencias pesadas.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test configuration helpers."""
 
 import sys
+import types
 from pathlib import Path
 
 
@@ -13,4 +14,140 @@ def _ensure_project_root_on_path() -> None:
         sys.path.insert(0, root_as_str)
 
 
+def _ensure_app_dir_on_path() -> None:
+    """Expose the ``app`` package as a namespace package for imports."""
+
+    app_dir = Path(__file__).resolve().parent.parent / "app"
+    app_dir_str = str(app_dir)
+    if app_dir.is_dir() and app_dir_str not in sys.path:
+        sys.path.insert(0, app_dir_str)
+
+
+def _install_stub_submodule(fullname: str, **attributes: object) -> None:
+    """Register a lightweight stub module under ``fullname`` if needed."""
+
+    if fullname in sys.modules:
+        return
+
+    module = types.ModuleType(fullname)
+    for attr_name, attr_value in attributes.items():
+        setattr(module, attr_name, attr_value)
+    sys.modules[fullname] = module
+
+    parent_name, _, child_name = fullname.rpartition(".")
+    if parent_name:
+        parent = sys.modules.get(parent_name)
+        if parent is None:
+            parent = types.ModuleType(parent_name)
+            sys.modules[parent_name] = parent
+        setattr(parent, child_name, module)
+
+
+def _install_langchain_stubs() -> None:
+    """Provide minimal stand-ins for optional langchain dependencies."""
+
+    try:  # pragma: no cover - only exercised when dependency is missing
+        import langchain  # type: ignore  # noqa: F401
+        import langchain_community  # type: ignore  # noqa: F401
+        import langchain_core  # type: ignore  # noqa: F401
+        import langchain.callbacks.streaming_stdout  # type: ignore  # noqa: F401
+    except Exception:  # pragma: no cover - stub path
+        _install_stub_submodule("langchain.chains", RetrievalQA=type("RetrievalQA", (), {}))
+
+        class _HuggingFaceEmbeddings:
+            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+                """Placeholder constructor."""
+
+        class _Ollama:
+            def __init__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+                """Placeholder constructor."""
+
+        _install_stub_submodule(
+            "langchain_community.embeddings",
+            HuggingFaceEmbeddings=_HuggingFaceEmbeddings,
+        )
+        _install_stub_submodule(
+            "langchain_community.llms",
+            Ollama=_Ollama,
+        )
+
+        class _StreamingStdOutCallbackHandler:
+            def __call__(self, *args: object, **kwargs: object) -> None:  # noqa: D401
+                """Placeholder callable."""
+
+        _install_stub_submodule(
+            "langchain.callbacks.streaming_stdout",
+            StreamingStdOutCallbackHandler=_StreamingStdOutCallbackHandler,
+        )
+
+        class _StrOutputParser:
+            def __call__(self, value: object) -> object:
+                return value
+
+        class _RunnablePassthrough:
+            def __call__(self, value: object) -> object:
+                return value
+
+        class _ChatPromptTemplate:
+            def __init__(self, messages: tuple[str, object]) -> None:
+                self.messages = messages
+
+            @classmethod
+            def from_messages(cls, messages: tuple[str, object]) -> "_ChatPromptTemplate":
+                return cls(messages)
+
+        _install_stub_submodule(
+            "langchain_core.output_parsers",
+            StrOutputParser=_StrOutputParser,
+        )
+        _install_stub_submodule(
+            "langchain_core.runnables",
+            RunnablePassthrough=_RunnablePassthrough,
+        )
+        _install_stub_submodule(
+            "langchain_core.prompts",
+            ChatPromptTemplate=_ChatPromptTemplate,
+        )
+
+
+def _install_common_stubs() -> None:
+    """Provide lightweight fallbacks for optional ``common`` modules."""
+
+    try:  # pragma: no cover - prefer real modules when available
+        import common.constants  # type: ignore  # noqa: F401
+        import common.chroma_db_settings  # type: ignore  # noqa: F401
+    except Exception:  # pragma: no cover - stub path
+        class _StubCollection:
+            def count(self) -> int:
+                return 1
+
+        class _StubChromaSettings:
+            def get_collection(self, name: str) -> _StubCollection:
+                return _StubCollection()
+
+        _install_stub_submodule(
+            "common.constants",
+            CHROMA_SETTINGS=_StubChromaSettings(),
+        )
+
+        class _StubRetriever:
+            def __ror__(self, other: object) -> object:
+                return other
+
+        class _StubChroma:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            def as_retriever(self, *args: object, **kwargs: object) -> _StubRetriever:
+                return _StubRetriever()
+
+        _install_stub_submodule(
+            "common.chroma_db_settings",
+            Chroma=_StubChroma,
+        )
+
+
 _ensure_project_root_on_path()
+_ensure_app_dir_on_path()
+_install_langchain_stubs()
+_install_common_stubs()

--- a/tests/test_langchain_module.py
+++ b/tests/test_langchain_module.py
@@ -1,0 +1,46 @@
+"""Tests for helpers in ``app.common.langchain_module``."""
+
+import pytest
+
+from app.common.langchain_module import detect_language, response
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("¿Cuál es la situación energética actual en España?", "es"),
+        ("What is the current energy policy status?", "en"),
+        ("La reunión is tomorrow", "es"),
+    ],
+)
+def test_detect_language_variants(text: str, expected: str) -> None:
+    """The helper should detect supported languages while preserving tildes."""
+
+    assert detect_language(text) == expected
+
+
+@pytest.mark.parametrize(
+    "query, expected_language, provided_language",
+    [
+        ("Hola, ¿cómo estás?", "es", None),
+        ("Hola, ¿cómo estás?", "es", ""),
+        ("Hello there", "en", None),
+        ("Hello there", "en", ""),
+    ],
+)
+def test_response_uses_detected_language_when_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    expected_language: str,
+    provided_language: str | None,
+) -> None:
+    """``response`` should fall back to detection for greetings when language is empty."""
+
+    def fake_get_text(key: str, language: str) -> str:
+        return f"{key}:{language}"
+
+    monkeypatch.setattr("app.common.langchain_module.get_text", fake_get_text)
+
+    result = response(query, language=provided_language)
+
+    assert result == f"greeting_response:{expected_language}"


### PR DESCRIPTION
## Summary
- add a `detect_language` helper that relies on `langdetect` and heuristics, and update `response` to auto-detect the fallback language
- document the detection strategy and add langdetect to the app requirements
- add unit tests and lightweight stubs so language detection can be exercised without heavy dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01b08e5fc832098f512698355ed3b