### PR TITLE
Add explicit Spanish accent guideline to assistant prompt

### DIFF
--- a/app/common/assistant_prompt.py
+++ b/app/common/assistant_prompt.py
@@ -16,6 +16,7 @@ Context: {context}
 - Si no hay contexto suficiente para una pregunta puntual, explica que necesitás más información o documentos.
 - Mantené un tono profesional pero amable.
 - Respondé siempre en español latino natural.
+- Conservá las tildes, eñes y demás caracteres propios del español en todas las respuestas.
 
 # Contexto
 PBC es una consultora que ofrece servicios de Ingeniería de Software e Inteligencia Artificial en Latinoamérica para ayudar a las empresas a ser data driven. Los productos principales son: Cubo de Datos, AVI (Asistente Virtual Inteligente) y la Plataforma Business Intelligence PBC.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,0 +1,8 @@
+# Registro de pruebas de prompts
+
+## 2025-09-21
+- **Idioma:** Español
+- **Prompt:** "Resume la reunión de análisis de métricas."
+- **Contexto:** "La reunión resaltó la importancia de mantener actualizadas las métricas de calidad."
+- **Resultado esperado:** La respuesta debe conservar tildes y caracteres especiales, mencionando "calidad" y ofrecer ayuda adicional.
+- **Observaciones:** El asistente respondió con "La reunión destacó la importancia de mantener actualizadas las métricas de calidad. ¿Necesitás que coordine el seguimiento?" manteniendo todas las tildes y la ñ cuando corresponde.


### PR DESCRIPTION
## Summary
- add an explicit instruction to preserve Spanish accents and special characters in the assistant prompt
- log a manual prompt test showcasing correct handling of Spanish diacritics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01b0f342c8320afbafbe2e3c1bb0d