### PR TITLE
Add automated RAG evaluation and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PYTHON ?= python3
+BLEU_THRESHOLD ?= 0.25
+ROUGE_THRESHOLD ?= 0.30
+EVAL_DATASETS := tests/fixtures/sample_responses_es.json tests/fixtures/sample_responses_en.json
+
+.PHONY: eval
+## Ejecuta la evaluación de respuestas RAG con métricas BLEU y ROUGE-L
+
+eval:
+	$(PYTHON) scripts/evaluate_responses.py --datasets $(EVAL_DATASETS) \
+		--bleu-threshold $(BLEU_THRESHOLD) --rouge-threshold $(ROUGE_THRESHOLD)

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,0 +1,52 @@
+# Control de calidad de respuestas RAG
+
+Este documento describe cómo evaluar respuestas generadas por el sistema RAG con datasets de referencia en español e inglés. El objetivo es contar con una verificación rápida que podamos automatizar en CI antes de desplegar cambios que afecten la calidad de las respuestas.
+
+## Script de evaluación
+
+El script [`scripts/evaluate_responses.py`](../scripts/evaluate_responses.py) calcula dos métricas básicas:
+
+- **BLEU** (BLEU-4 suavizado) para medir la coincidencia de n-gramas entre las respuestas del RAG y las referencias.
+- **ROUGE-L** para capturar la superposición basada en subsecuencias entre ambas respuestas.
+
+Por defecto el script busca datasets en `tests/fixtures/sample_responses_es.json` y `tests/fixtures/sample_responses_en.json`, que contienen pares de pregunta, respuesta de referencia y respuesta candidata. Los datasets de ejemplo se construyeron para reflejar estructuras lingüísticas comunes en ambos idiomas.
+
+## Cómo ejecutar la evaluación
+
+El repositorio incluye una tarea de Make para integrar la verificación en pipelines de CI/CD:
+
+```bash
+make eval
+```
+
+Variables opcionales:
+
+- `BLEU_THRESHOLD`: valor mínimo permitido para el promedio de BLEU (por defecto `0.25`).
+- `ROUGE_THRESHOLD`: valor mínimo permitido para el promedio de ROUGE-L (por defecto `0.30`).
+- `PYTHON`: intérprete de Python a utilizar.
+
+El comando termina con código de salida distinto de cero si algún dataset evaluado queda por debajo de los umbrales definidos.
+
+## Umbrales mínimos
+
+Los umbrales por defecto se fijaron con base en las métricas obtenidas sobre los datasets incluidos:
+
+- BLEU promedio ≥ **0.25**
+- ROUGE-L promedio ≥ **0.30**
+
+Estos valores representan un punto de partida conservador que permite detectar respuestas con poca superposición frente a la referencia sin exigir coincidencia exacta.
+
+## Interpretación de resultados
+
+Al ejecutar el script se imprime un resumen por dataset y un promedio global:
+
+- `OK`: el dataset supera ambos umbrales.
+- `FALLO`: al menos una métrica queda por debajo del mínimo configurado.
+
+En caso de fallo se recomienda revisar:
+
+1. La calidad de la respuesta candidata y su alineación semántica con la referencia.
+2. Posibles problemas de tokenización o limpieza del texto de entrada.
+3. Si los umbrales deben ajustarse para el dominio evaluado (por ejemplo, respuestas muy creativas o resúmenes largos).
+
+El parámetro `--save-report` permite generar un archivo JSON con métricas detalladas por pregunta, útil para depurar o visualizar tendencias en dashboards externos.

--- a/scripts/evaluate_responses.py
+++ b/scripts/evaluate_responses.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Utility to evaluate RAG responses against reference answers.
+
+The script computes basic BLEU and ROUGE-L metrics for multilingual
+fixtures to provide a lightweight quality gate that can be automated in CI.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass
+class EvaluationItem:
+    """Container for a single question/response pair."""
+
+    question: str
+    reference: str
+    candidate: str
+    bleu: float
+    rouge_l: float
+
+
+@dataclass
+class DatasetEvaluation:
+    """Aggregated results for a dataset in a specific language."""
+
+    path: Path
+    language: str
+    size: int
+    bleu: float
+    rouge_l: float
+    items: List[EvaluationItem]
+
+
+_TOKEN_PATTERN = re.compile(r"\w+", re.UNICODE)
+
+
+def tokenize(text: str) -> List[str]:
+    """Tokenise text into lower-case word tokens for metric computation."""
+
+    return _TOKEN_PATTERN.findall(text.lower())
+
+
+def _generate_ngrams(tokens: Sequence[str], n: int) -> Iterable[Sequence[str]]:
+    for i in range(len(tokens) - n + 1):
+        yield tuple(tokens[i : i + n])
+
+
+def compute_bleu(reference_tokens: Sequence[str], candidate_tokens: Sequence[str], max_n: int = 4) -> float:
+    """Compute a smoothed BLEU score for a candidate against a reference."""
+
+    candidate_len = len(candidate_tokens)
+    reference_len = len(reference_tokens)
+
+    if candidate_len == 0:
+        return 0.0
+
+    effective_max_n = min(max_n, candidate_len)
+    weights = [1 / effective_max_n] * effective_max_n
+
+    precisions: List[float] = []
+    ref_counters: Dict[int, Counter] = {}
+
+    for n in range(1, effective_max_n + 1):
+        cand_ngrams = Counter(_generate_ngrams(candidate_tokens, n))
+        if n not in ref_counters:
+            ref_counters[n] = Counter(_generate_ngrams(reference_tokens, n))
+        ref_ngrams = ref_counters[n]
+        overlap = sum(min(count, ref_ngrams[ngram]) for ngram, count in cand_ngrams.items())
+        total = sum(cand_ngrams.values())
+        if total == 0:
+            precisions.append(0.0)
+        else:
+            precisions.append((overlap + 1) / (total + 1))
+
+    if not precisions or any(p == 0 for p in precisions):
+        geo_mean = 0.0
+    else:
+        geo_mean = math.exp(sum(weight * math.log(p) for weight, p in zip(weights, precisions)))
+
+    if candidate_len > reference_len:
+        brevity_penalty = 1.0
+    else:
+        brevity_penalty = math.exp(1 - reference_len / candidate_len)
+
+    return brevity_penalty * geo_mean
+
+
+def _lcs_length(reference_tokens: Sequence[str], candidate_tokens: Sequence[str]) -> int:
+    ref_len = len(reference_tokens)
+    cand_len = len(candidate_tokens)
+    if ref_len == 0 or cand_len == 0:
+        return 0
+
+    dp = [[0] * (cand_len + 1) for _ in range(ref_len + 1)]
+    for i in range(1, ref_len + 1):
+        for j in range(1, cand_len + 1):
+            if reference_tokens[i - 1] == candidate_tokens[j - 1]:
+                dp[i][j] = dp[i - 1][j - 1] + 1
+            else:
+                dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+    return dp[-1][-1]
+
+
+def compute_rouge_l(reference_tokens: Sequence[str], candidate_tokens: Sequence[str], beta: float = 1.2) -> float:
+    """Compute ROUGE-L based on longest common subsequence."""
+
+    lcs = _lcs_length(reference_tokens, candidate_tokens)
+    if lcs == 0:
+        return 0.0
+
+    recall = lcs / len(reference_tokens) if reference_tokens else 0.0
+    precision = lcs / len(candidate_tokens) if candidate_tokens else 0.0
+
+    if recall == 0 or precision == 0:
+        return 0.0
+
+    beta_sq = beta ** 2
+    return (1 + beta_sq) * recall * precision / (recall + beta_sq * precision)
+
+
+def evaluate_dataset(path: Path) -> DatasetEvaluation:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    items_payload = payload.get("items", [])
+    language = payload.get("language", "unknown")
+
+    evaluation_items: List[EvaluationItem] = []
+
+    for item in items_payload:
+        reference = item["reference"]
+        candidate = item["candidate"]
+        reference_tokens = tokenize(reference)
+        candidate_tokens = tokenize(candidate)
+        bleu = compute_bleu(reference_tokens, candidate_tokens)
+        rouge_l = compute_rouge_l(reference_tokens, candidate_tokens)
+        evaluation_items.append(
+            EvaluationItem(
+                question=item.get("question", ""),
+                reference=reference,
+                candidate=candidate,
+                bleu=bleu,
+                rouge_l=rouge_l,
+            )
+        )
+
+    dataset_bleu = sum(item.bleu for item in evaluation_items) / len(evaluation_items) if evaluation_items else 0.0
+    dataset_rouge = sum(item.rouge_l for item in evaluation_items) / len(evaluation_items) if evaluation_items else 0.0
+
+    return DatasetEvaluation(
+        path=path,
+        language=language,
+        size=len(evaluation_items),
+        bleu=dataset_bleu,
+        rouge_l=dataset_rouge,
+        items=evaluation_items,
+    )
+
+
+def format_metric(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parents[1]
+    default_datasets = [
+        root / "tests" / "fixtures" / "sample_responses_es.json",
+        root / "tests" / "fixtures" / "sample_responses_en.json",
+    ]
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        type=Path,
+        default=default_datasets,
+        help="Ruta(s) a los archivos JSON con preguntas, referencias y respuestas evaluadas.",
+    )
+    parser.add_argument("--bleu-threshold", type=float, default=0.25, help="Mínimo BLEU promedio permitido.")
+    parser.add_argument(
+        "--rouge-threshold", type=float, default=0.30, help="Mínimo ROUGE-L promedio permitido."
+    )
+    parser.add_argument(
+        "--save-report",
+        type=Path,
+        help="Ruta opcional para almacenar un informe JSON con los resultados detallados.",
+    )
+
+    args = parser.parse_args()
+
+    datasets: List[DatasetEvaluation] = []
+    for dataset_path in args.datasets:
+        if not dataset_path.exists():
+            raise FileNotFoundError(f"No se encontró el dataset: {dataset_path}")
+        datasets.append(evaluate_dataset(dataset_path))
+
+    total_items = sum(dataset.size for dataset in datasets)
+    overall_bleu = (
+        sum(dataset.bleu * dataset.size for dataset in datasets) / total_items if total_items else 0.0
+    )
+    overall_rouge = (
+        sum(dataset.rouge_l * dataset.size for dataset in datasets) / total_items if total_items else 0.0
+    )
+
+    thresholds = {"bleu": args.bleu_threshold, "rouge_l": args.rouge_threshold}
+
+    overall_pass = True
+    for dataset in datasets:
+        dataset_pass = dataset.bleu >= thresholds["bleu"] and dataset.rouge_l >= thresholds["rouge_l"]
+        if not dataset_pass:
+            overall_pass = False
+
+    if overall_bleu < thresholds["bleu"] or overall_rouge < thresholds["rouge_l"]:
+        overall_pass = False
+
+    if not datasets:
+        overall_pass = False
+
+    print("Evaluación de respuestas RAG")
+    print("============================")
+    print(f"Umbrales -> BLEU ≥ {thresholds['bleu']:.2f}, ROUGE-L ≥ {thresholds['rouge_l']:.2f}")
+    print()
+
+    for dataset in datasets:
+        dataset_pass = dataset.bleu >= thresholds["bleu"] and dataset.rouge_l >= thresholds["rouge_l"]
+        status = "OK" if dataset_pass else "FALLO"
+        print(
+            f"- {dataset.path.name} [{dataset.language}] (n={dataset.size}): "
+            f"BLEU={format_metric(dataset.bleu)}, ROUGE-L={format_metric(dataset.rouge_l)} -> {status}"
+        )
+
+    print()
+    overall_status = "OK" if overall_pass else "FALLO"
+    print(
+        f"Promedio global (n={total_items}): BLEU={format_metric(overall_bleu)}, "
+        f"ROUGE-L={format_metric(overall_rouge)} -> {overall_status}"
+    )
+
+    if args.save_report:
+        report = {
+            "thresholds": thresholds,
+            "datasets": [
+                {
+                    "path": str(dataset.path),
+                    "language": dataset.language,
+                    "size": dataset.size,
+                    "bleu": dataset.bleu,
+                    "rouge_l": dataset.rouge_l,
+                    "items": [
+                        {
+                            "question": item.question,
+                            "reference": item.reference,
+                            "candidate": item.candidate,
+                            "bleu": item.bleu,
+                            "rouge_l": item.rouge_l,
+                        }
+                        for item in dataset.items
+                    ],
+                }
+                for dataset in datasets
+            ],
+            "overall": {"bleu": overall_bleu, "rouge_l": overall_rouge, "items": total_items},
+            "passed": overall_pass,
+        }
+        args.save_report.parent.mkdir(parents=True, exist_ok=True)
+        with args.save_report.open("w", encoding="utf-8") as handle:
+            json.dump(report, handle, ensure_ascii=False, indent=2)
+        print(f"\nInforme guardado en {args.save_report}")
+
+    if not overall_pass:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample_responses_en.json
+++ b/tests/fixtures/sample_responses_en.json
@@ -1,0 +1,15 @@
+{
+  "language": "en",
+  "items": [
+    {
+      "question": "What is retrieval augmented generation?",
+      "reference": "Retrieval augmented generation combines search over external knowledge with text generation to produce grounded answers.",
+      "candidate": "Retrieval augmented generation combines search over external knowledge with text generation to produce grounded answers."
+    },
+    {
+      "question": "Why monitor data quality?",
+      "reference": "Monitoring data quality helps catch drifting sources early and prevents the assistant from returning outdated facts.",
+      "candidate": "Monitoring data quality helps detect drifting sources early and prevents the assistant from returning outdated facts."
+    }
+  ]
+}

--- a/tests/fixtures/sample_responses_es.json
+++ b/tests/fixtures/sample_responses_es.json
@@ -1,0 +1,15 @@
+{
+  "language": "es",
+  "items": [
+    {
+      "question": "¿Qué es Anclora RAG?",
+      "reference": "Anclora RAG es un sistema de recuperación aumentada que combina búsqueda semántica con generación para responder preguntas empresariales.",
+      "candidate": "Anclora RAG es una plataforma de recuperación aumentada que mezcla búsqueda semántica y generación para contestar preguntas de negocio."
+    },
+    {
+      "question": "¿Cómo se actualiza la base de conocimiento?",
+      "reference": "La base de conocimiento se actualiza agregando nuevos documentos al índice y reejecutando el proceso de ingestión.",
+      "candidate": "Se actualiza añadiendo documentos al índice y ejecutando nuevamente la ingestión de datos."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Python utility to score RAG responses with BLEU and ROUGE-L using bilingual fixtures
- provide sample evaluation datasets and document quality thresholds and interpretation guidance
- expose a `make eval` target to run the quality gate in CI pipelines

## Testing
- make eval

------
https://chatgpt.com/codex/tasks/task_e_68d01b1b87948320b672a0b08f8e3599