### PR TITLE
feat: enhance rag client language and auth handling

### DIFF
--- a/anclora_rag_client.py
+++ b/anclora_rag_client.py
@@ -2,36 +2,136 @@
 Cliente Python para que agentes IA accedan al sistema Anclora RAG
 """
 
-import requests
-import json
 import logging
-from typing import Optional, List, Dict, Any
 from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
 
 class AncloraRAGClient:
     """
-    Cliente para interactuar con el sistema Anclora RAG desde agentes IA
+    Cliente para interactuar con el sistema Anclora RAG desde agentes IA.
+
+    El cliente permite configurar el esquema de autenticación, seleccionar el
+    idioma preferido para las respuestas y maneja automáticamente respuestas
+    con caracteres especiales gracias a la normalización del encoding HTTP.
     """
     
-    def __init__(self, base_url: str = "http://localhost:8081", api_key: str = "your-api-key-here"):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8081",
+        api_key: str = "your-api-key-here",
+        *,
+        auth_scheme: str = "Bearer",
+        default_language: str = "es",
+        supported_languages: Optional[List[str]] = None,
+    ):
         """
         Inicializar cliente RAG
-        
+
         Args:
             base_url (str): URL base del sistema RAG
             api_key (str): Clave de API para autenticación
+            auth_scheme (str): Esquema de autenticación HTTP (Bearer, Token, etc.)
+            default_language (str): Idioma por defecto para las consultas
+            supported_languages (Optional[List[str]]): Lista de idiomas permitidos
         """
         self.base_url = base_url.rstrip('/')
-        self.api_key = api_key
         self.session = requests.Session()
-        self.session.headers.update({
-            'Authorization': f'Bearer {api_key}',
-            'Content-Type': 'application/json'
-        })
-        
-        # Configurar logging
+        self.session.headers.update({'Content-Type': 'application/json'})
+
         self.logger = logging.getLogger(__name__)
-    
+
+        self._supported_languages = self._normalize_languages(supported_languages)
+        self.language = self._validate_language(default_language)
+
+        self.auth_scheme: Optional[str] = auth_scheme.strip() if auth_scheme is not None else None
+        self._auth_token: Optional[str] = None
+        self.api_key: Optional[str] = None
+        if api_key:
+            self.set_auth_token(api_key, auth_scheme=self.auth_scheme)
+
+    @staticmethod
+    def _normalize_languages(languages: Optional[List[str]]) -> Optional[List[str]]:
+        if languages is None:
+            return ["es", "en"]
+
+        cleaned: List[str] = []
+        for language in languages:
+            if not isinstance(language, str):
+                continue
+            normalized = language.strip().lower()
+            if normalized and normalized not in cleaned:
+                cleaned.append(normalized)
+
+        return cleaned or ["es", "en"]
+
+    def _validate_language(self, language: Optional[str]) -> str:
+        if not isinstance(language, str):
+            raise ValueError("El idioma debe ser una cadena de texto.")
+
+        normalized = language.strip().lower()
+        if not normalized:
+            raise ValueError("El idioma no puede estar vacío.")
+
+        if self._supported_languages and normalized not in self._supported_languages:
+            raise ValueError(
+                f"Idioma '{normalized}' no soportado. Idiomas disponibles: {', '.join(self._supported_languages)}"
+            )
+
+        return normalized
+
+    def set_language(self, language: str) -> str:
+        """Actualizar el idioma por defecto para las consultas."""
+
+        self.language = self._validate_language(language)
+        return self.language
+
+    def _validate_token(self, token: str) -> str:
+        if not isinstance(token, str):
+            raise ValueError("El token de autenticación debe ser una cadena de texto.")
+
+        cleaned = token.strip()
+        if not cleaned:
+            raise ValueError("El token de autenticación no puede estar vacío.")
+
+        return cleaned
+
+    def set_auth_token(self, token: str, auth_scheme: Optional[str] = None) -> None:
+        """Configurar el token de autenticación y el esquema utilizado."""
+
+        cleaned_token = self._validate_token(token)
+
+        if auth_scheme is not None:
+            scheme = auth_scheme.strip()
+            if not scheme and auth_scheme != "":
+                raise ValueError("El esquema de autenticación no puede estar vacío.")
+            self.auth_scheme = scheme
+
+        scheme = self.auth_scheme
+        if scheme is None:
+            scheme = "Bearer"
+
+        header_value = f"{scheme} {cleaned_token}" if scheme else cleaned_token
+
+        self._auth_token = cleaned_token
+        self.api_key = cleaned_token
+        self.session.headers['Authorization'] = header_value
+
+    def _ensure_authenticated(self) -> None:
+        if not self._auth_token:
+            raise ValueError("No se ha configurado un token de autenticación válido.")
+
+    @staticmethod
+    def _ensure_utf8(response: requests.Response) -> None:
+        if not response.encoding:
+            response.encoding = response.apparent_encoding or 'utf-8'
+
+    def _add_language_to_payload(self, payload: Dict[str, Any], language: Optional[str]) -> None:
+        selected_language = language or self.language
+        if selected_language:
+            payload['language'] = self._validate_language(selected_language)
+
     def health_check(self) -> Dict[str, Any]:
         """
         Verificar estado del sistema RAG
@@ -42,31 +142,42 @@ class AncloraRAGClient:
         try:
             response = self.session.get(f"{self.base_url}/health")
             response.raise_for_status()
+            self._ensure_utf8(response)
             return response.json()
         except requests.exceptions.RequestException as e:
             self.logger.error(f"Error en health check: {e}")
             return {"status": "error", "message": str(e)}
     
-    def query(self, message: str, max_length: int = 1000) -> Dict[str, Any]:
+    def query(
+        self,
+        message: str,
+        max_length: int = 1000,
+        language: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Realizar consulta al sistema RAG
         
         Args:
             message (str): Pregunta o consulta
             max_length (int): Longitud máxima del mensaje
-            
+            language (Optional[str]): Idioma a utilizar en la consulta
+
         Returns:
             Dict con la respuesta del RAG
         """
         try:
+            self._ensure_authenticated()
+
             payload = {
                 "message": message,
                 "max_length": max_length
             }
-            
+            self._add_language_to_payload(payload, language)
+
             response = self.session.post(f"{self.base_url}/chat", json=payload)
             response.raise_for_status()
-            
+
+            self._ensure_utf8(response)
             result = response.json()
             self.logger.info(f"Consulta exitosa: {message[:50]}...")
             return result
@@ -89,19 +200,22 @@ class AncloraRAGClient:
             file_path = Path(file_path)
             if not file_path.exists():
                 return {"status": "error", "message": "Archivo no encontrado"}
-            
+
             with open(file_path, 'rb') as f:
                 files = {'file': (file_path.name, f, 'application/octet-stream')}
                 # Remover Content-Type header para multipart
-                headers = {'Authorization': f'Bearer {self.api_key}'}
-                
+                self._ensure_authenticated()
+                auth_header = self.session.headers.get('Authorization')
+                headers = {'Authorization': auth_header} if auth_header else {}
+
                 response = requests.post(
                     f"{self.base_url}/upload",
                     files=files,
                     headers=headers
                 )
                 response.raise_for_status()
-            
+
+            self._ensure_utf8(response)
             result = response.json()
             self.logger.info(f"Documento subido: {file_path.name}")
             return result
@@ -118,8 +232,10 @@ class AncloraRAGClient:
             Dict con lista de documentos
         """
         try:
+            self._ensure_authenticated()
             response = self.session.get(f"{self.base_url}/documents")
             response.raise_for_status()
+            self._ensure_utf8(response)
             return response.json()
             
         except requests.exceptions.RequestException as e:
@@ -137,9 +253,11 @@ class AncloraRAGClient:
             Dict con resultado de la operación
         """
         try:
+            self._ensure_authenticated()
             response = self.session.delete(f"{self.base_url}/documents/{filename}")
             response.raise_for_status()
-            
+
+            self._ensure_utf8(response)
             result = response.json()
             self.logger.info(f"Documento eliminado: {filename}")
             return result
@@ -148,19 +266,20 @@ class AncloraRAGClient:
             self.logger.error(f"Error al eliminar documento: {e}")
             return {"status": "error", "message": str(e)}
     
-    def batch_query(self, messages: List[str]) -> List[Dict[str, Any]]:
+    def batch_query(self, messages: List[str], language: Optional[str] = None) -> List[Dict[str, Any]]:
         """
         Realizar múltiples consultas en lote
         
         Args:
             messages (List[str]): Lista de mensajes/consultas
-            
+            language (Optional[str]): Idioma a utilizar para todas las consultas
+
         Returns:
             Lista de respuestas
         """
         results = []
         for message in messages:
-            result = self.query(message)
+            result = self.query(message, language=language)
             results.append(result)
         return results
 
@@ -168,24 +287,52 @@ class AncloraRAGClient:
 # Ejemplo de uso para agentes IA
 class AIAgentRAGInterface:
     """
-    Interfaz simplificada para agentes IA
+    Interfaz simplificada para agentes IA.
+
+    Ofrece helpers para ajustar el token de autenticación y el idioma antes de
+    interactuar con el servicio RAG.
     """
-    
-    def __init__(self, rag_url: str = "http://localhost:8081", api_key: str = "your-api-key-here"):
-        self.client = AncloraRAGClient(rag_url, api_key)
+
+    def __init__(
+        self,
+        rag_url: str = "http://localhost:8081",
+        api_key: str = "your-api-key-here",
+        *,
+        auth_scheme: str = "Bearer",
+        default_language: str = "es",
+        supported_languages: Optional[List[str]] = None,
+    ):
+        self.client = AncloraRAGClient(
+            rag_url,
+            api_key,
+            auth_scheme=auth_scheme,
+            default_language=default_language,
+            supported_languages=supported_languages,
+        )
         self.logger = logging.getLogger(__name__)
-    
-    def ask_question(self, question: str) -> str:
+
+    def set_auth_token(self, token: str, auth_scheme: Optional[str] = None) -> None:
+        """Actualizar el token de autenticación utilizado por el agente."""
+
+        self.client.set_auth_token(token, auth_scheme=auth_scheme)
+
+    def set_language(self, language: str) -> str:
+        """Actualizar el idioma por defecto utilizado por el agente."""
+
+        return self.client.set_language(language)
+
+    def ask_question(self, question: str, language: Optional[str] = None) -> str:
         """
         Hacer una pregunta simple al RAG
-        
+
         Args:
             question (str): Pregunta
-            
+            language (Optional[str]): Idioma de la respuesta
+
         Returns:
             str: Respuesta del RAG
         """
-        result = self.client.query(question)
+        result = self.client.query(question, language=language)
         if result.get("status") == "success":
             return result.get("response", "Sin respuesta")
         else:
@@ -231,18 +378,26 @@ class AIAgentRAGInterface:
 if __name__ == "__main__":
     # Configurar logging
     logging.basicConfig(level=logging.INFO)
-    
+
     # Crear interfaz para agente IA
     ai_interface = AIAgentRAGInterface()
-    
+
+    # Configurar token y lenguaje si fuese necesario
+    ai_interface.set_auth_token("your-api-key-here", auth_scheme="Bearer")
+    ai_interface.set_language("es")
+
     # Verificar salud del sistema
     if ai_interface.is_healthy():
         print("✅ Sistema RAG disponible")
-        
+
         # Hacer una consulta
-        response = ai_interface.ask_question("¿Cuáles son los productos de PBC?")
+        response = ai_interface.ask_question("¿Cuáles son los productos de PBC?", language="es")
         print(f"Respuesta: {response}")
-        
+
+        # Realizar una consulta en inglés
+        response_en = ai_interface.ask_question("Which are the PBC products?", language="en")
+        print(f"Respuesta (en): {response_en}")
+
         # Listar documentos
         docs = ai_interface.get_available_documents()
         print(f"Documentos disponibles: {docs}")

--- a/docs/api/client_examples.md
+++ b/docs/api/client_examples.md
@@ -1,0 +1,68 @@
+# Ejemplos del cliente `AncloraRAGClient`
+
+Estos fragmentos muestran cómo configurar el cliente Python para conectarse a un despliegue de Anclora RAG.
+
+## Inicialización y verificación de salud
+
+```python
+from anclora_rag_client import AncloraRAGClient
+
+client = AncloraRAGClient(
+    base_url="http://localhost:8081",
+    api_key="mi-token-super-seguro",
+)
+
+salud = client.health_check()
+print(salud["status"])
+```
+
+## Configurar token y esquema de autenticación
+
+El nuevo esquema permite rotar el token y definir el prefijo a utilizar en la cabecera `Authorization`.
+
+```python
+client.set_auth_token("token-rotado-123", auth_scheme="Token")
+```
+
+Si la API espera el token sin prefijo puede establecerse `auth_scheme=""`.
+
+## Seleccionar idioma de trabajo
+
+```python
+# Establecer idioma por defecto
+client.set_language("en")
+
+# Sobrescribir idioma en una consulta concreta
+respuesta = client.query("¿Qué productos ofrece PBC?", language="es")
+print(respuesta["response"])
+```
+
+El cliente valida automáticamente que el idioma solicitado esté en la lista de soportados. Si se requiere un conjunto distinto basta con proporcionar la lista en el constructor:
+
+```python
+client = AncloraRAGClient(
+    api_key="mi-token",
+    supported_languages=["es", "en", "pt"],
+    default_language="pt",
+)
+```
+
+## Manejo de caracteres especiales en respuestas
+
+Las respuestas que contienen tildes, eñes u otros caracteres Unicode se mantienen intactas gracias a la normalización automática del encoding HTTP.
+
+```python
+resultado = client.query("¿Cuál es la visión de la empresa?", language="es")
+print(resultado["response"])  # Ejemplo: "La visión es innovación continua"
+```
+
+## Uso con la interfaz de agente
+
+```python
+from anclora_rag_client import AIAgentRAGInterface
+
+agent = AIAgentRAGInterface(api_key="mi-token", default_language="es")
+agent.set_auth_token("nuevo-token", auth_scheme="Bearer")
+agent.set_language("en")
+print(agent.ask_question("Which are the PBC products?"))
+```

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+import pytest
+
+from anclora_rag_client import AncloraRAGClient
+
+
+class DummyResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self.encoding = None
+        self.apparent_encoding = "utf-8"
+
+    def raise_for_status(self) -> None:  # pragma: no cover - behaviour is mocked
+        return None
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def test_query_uses_selected_language_and_preserves_unicode():
+    client = AncloraRAGClient(api_key="token", supported_languages=["es", "en"])
+    client.set_language("en")
+
+    response_payload = {"status": "success", "response": "¡Hola, mundo!"}
+    fake_response = DummyResponse(response_payload)
+
+    with patch.object(client.session, "post", return_value=fake_response) as mock_post:
+        result = client.query("Hola")
+
+    _, kwargs = mock_post.call_args
+    payload = kwargs["json"]
+
+    assert payload["language"] == "en"
+    assert result == response_payload
+    assert fake_response.encoding == "utf-8"
+
+
+def test_batch_query_propagates_language():
+    client = AncloraRAGClient(api_key="token")
+
+    with patch.object(client, "query", return_value={"status": "success"}) as mock_query:
+        client.batch_query(["uno", "dos"], language="es")
+
+    assert mock_query.call_count == 2
+    for call in mock_query.call_args_list:
+        assert call.kwargs["language"] == "es"
+
+
+def test_set_auth_token_allows_custom_scheme():
+    client = AncloraRAGClient(api_key="token")
+
+    client.set_auth_token("nuevo-token", auth_scheme="Token")
+    assert client.session.headers["Authorization"] == "Token nuevo-token"
+
+    client.set_auth_token("sin-prefijo", auth_scheme="")
+    assert client.session.headers["Authorization"] == "sin-prefijo"
+
+
+def test_set_auth_token_rejects_empty_value():
+    client = AncloraRAGClient(api_key="token")
+
+    with pytest.raises(ValueError):
+        client.set_auth_token("   ")
+
+
+def test_query_requires_authentication_token():
+    client = AncloraRAGClient(api_key="")
+
+    with pytest.raises(ValueError):
+        client.query("Hola")


### PR DESCRIPTION
## Summary
- add configurable language selection, encoding handling and token validation to the Python RAG client
- extend the AI agent helper with helpers to update language and authentication dynamically
- document client usage with new examples and cover the behaviour with unit tests

## Testing
- pytest tests/client/test_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d01e4f340c83208a01c56682ca3333