### PR TITLE
feat: scaffold multi-agent orchestrator

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,17 @@
+"""Agent package exposing orchestrator flows and concrete agent implementations."""
+
+from .base import AgentResponse, AgentTask, BaseAgent
+from .document_agent import DocumentAgent
+from .media_agent import MediaAgent
+from .orchestrator import OrchestratorService, create_default_orchestrator, document_query_flow
+
+__all__ = [
+    "AgentResponse",
+    "AgentTask",
+    "BaseAgent",
+    "DocumentAgent",
+    "MediaAgent",
+    "OrchestratorService",
+    "create_default_orchestrator",
+    "document_query_flow",
+]

--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -1,0 +1,56 @@
+"""Shared contracts for agent collaboration within the RAG platform."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class AgentTask:
+    """Describe una tarea que puede ser delegada a un agente especializado."""
+
+    task_type: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    def get(self, key: str, default: Any | None = None) -> Any | None:
+        """Utility helper to read values from payload or context."""
+
+        if key in self.payload:
+            return self.payload.get(key, default)
+        if key in self.context:
+            return self.context.get(key, default)
+        return default
+
+
+@dataclass(slots=True)
+class AgentResponse:
+    """Resultado estandarizado de la ejecución de una tarea."""
+
+    success: bool
+    data: Optional[Any] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+class BaseAgent(ABC):
+    """Interfaz base que todos los agentes deben implementar."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        """Nombre descriptivo del agente."""
+
+        return self._name
+
+    @abstractmethod
+    def can_handle(self, task: AgentTask) -> bool:
+        """Indica si el agente puede gestionar la tarea solicitada."""
+
+    @abstractmethod
+    def handle(self, task: AgentTask) -> AgentResponse:
+        """Procesa la tarea delegada y devuelve un :class:`AgentResponse`."""

--- a/app/agents/document_agent/__init__.py
+++ b/app/agents/document_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Implementaciones especializadas para consultas sobre documentos."""
+
+from .agent import DocumentAgent
+
+__all__ = ["DocumentAgent"]

--- a/app/agents/document_agent/agent.py
+++ b/app/agents/document_agent/agent.py
@@ -1,0 +1,43 @@
+"""Document-centric agent implementation leveraging the LangChain RAG core."""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from app.agents.base import AgentResponse, AgentTask, BaseAgent
+from app.common import langchain_module
+
+QueryFunction = Callable[[str, Optional[str]], str]
+
+
+class DocumentAgent(BaseAgent):
+    """Agent responsible for answering document-related questions via RAG."""
+
+    def __init__(self, query_function: QueryFunction | None = None) -> None:
+        super().__init__(name="document_agent")
+        self._query_function: QueryFunction = query_function or langchain_module.response
+
+    def can_handle(self, task: AgentTask) -> bool:
+        """Only handle ``document_query`` tasks."""
+
+        return task.task_type == "document_query"
+
+    def handle(self, task: AgentTask) -> AgentResponse:
+        """Run the query through the RAG pipeline and standardise the response."""
+
+        question = task.get("question")
+        language = task.get("language")
+
+        if not question:
+            return AgentResponse(success=False, error="question_missing")
+
+        try:
+            answer = self._query_function(str(question), language if language else None)
+        except Exception as exc:  # pragma: no cover - defensive branch
+            return AgentResponse(success=False, error=str(exc))
+
+        return AgentResponse(
+            success=True,
+            data={"answer": answer},
+            metadata={"language": language},
+        )

--- a/app/agents/media_agent/__init__.py
+++ b/app/agents/media_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agente responsable de tareas básicas sobre contenidos multimedia."""
+
+from .agent import MediaAgent
+
+__all__ = ["MediaAgent"]

--- a/app/agents/media_agent/agent.py
+++ b/app/agents/media_agent/agent.py
@@ -1,0 +1,30 @@
+"""Media agent offering lightweight placeholders for future multimedia workflows."""
+
+from __future__ import annotations
+
+from app.agents.base import AgentResponse, AgentTask, BaseAgent
+
+
+class MediaAgent(BaseAgent):
+    """Provide basic responses for media-oriented tasks until a full pipeline is added."""
+
+    SUPPORTED_TASKS = {"media_transcription", "media_summary"}
+
+    def __init__(self) -> None:
+        super().__init__(name="media_agent")
+
+    def can_handle(self, task: AgentTask) -> bool:
+        return task.task_type in self.SUPPORTED_TASKS
+
+    def handle(self, task: AgentTask) -> AgentResponse:
+        media_ref = task.get("media")
+        if not media_ref:
+            return AgentResponse(success=False, error="media_reference_missing")
+
+        return AgentResponse(
+            success=True,
+            data={
+                "message": "Media task acknowledged. Implement post-processing pipeline to extend capabilities.",
+                "media": media_ref,
+            },
+        )

--- a/app/agents/orchestrator/__init__.py
+++ b/app/agents/orchestrator/__init__.py
@@ -1,0 +1,9 @@
+"""Servicios de orquestación y ejemplos de flujos multi-agente."""
+
+from .service import OrchestratorService, create_default_orchestrator, document_query_flow
+
+__all__ = [
+    "OrchestratorService",
+    "create_default_orchestrator",
+    "document_query_flow",
+]

--- a/app/agents/orchestrator/service.py
+++ b/app/agents/orchestrator/service.py
@@ -1,0 +1,60 @@
+"""High level orchestration primitives coordinating specialised agents."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import List, Sequence
+
+from app.agents.base import AgentResponse, AgentTask, BaseAgent
+from app.agents.document_agent import DocumentAgent
+from app.agents.media_agent import MediaAgent
+
+
+class OrchestratorService:
+    """Coordinate task delegation between the available agents."""
+
+    def __init__(self, agents: Sequence[BaseAgent] | None = None) -> None:
+        self._agents: "OrderedDict[str, BaseAgent]" = OrderedDict()
+        if agents:
+            for agent in agents:
+                self.register_agent(agent)
+
+    def register_agent(self, agent: BaseAgent) -> None:
+        """Register or update an agent implementation."""
+
+        self._agents[agent.name] = agent
+
+    def available_agents(self) -> List[str]:
+        """Return the registered agent names preserving registration order."""
+
+        return list(self._agents.keys())
+
+    def execute(self, task: AgentTask) -> AgentResponse:
+        """Delegate execution to the first agent that declares support."""
+
+        for agent in self._agents.values():
+            if agent.can_handle(task):
+                return agent.handle(task)
+
+        return AgentResponse(success=False, error=f"no_agent_for_{task.task_type}")
+
+
+def create_default_orchestrator() -> OrchestratorService:
+    """Build an orchestrator with the default agents described in the report."""
+
+    return OrchestratorService(agents=[DocumentAgent(), MediaAgent()])
+
+
+def document_query_flow(question: str, language: str | None = None, orchestrator: OrchestratorService | None = None) -> AgentResponse:
+    """Example flow that routes a document question through the orchestrator.
+
+    The flow performs three simple steps:
+
+    1. Construye la tarea con la consulta y metadatos opcionales (idioma, contexto).
+    2. Delegates execution to the orchestrator, which selects the :class:`DocumentAgent`.
+    3. Retorna la respuesta estandarizada del agente con el campo ``answer`` listo para la UI o APIs.
+    """
+
+    service = orchestrator or create_default_orchestrator()
+    task = AgentTask(task_type="document_query", payload={"question": question, "language": language})
+    return service.execute(task)

--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -2,14 +2,16 @@
 API REST para acceso de agentes IA al sistema Anclora RAG
 """
 
+import json
 import logging
 import os
 import secrets
 from typing import List, Optional
 
-from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi import Body, Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from common.langchain_module import response
 
 # Configurar logging

--- a/tests/agents/test_orchestrator.py
+++ b/tests/agents/test_orchestrator.py
@@ -1,0 +1,59 @@
+"""Basic integration checks for the multi-agent orchestration layer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.agents.base import AgentTask
+from app.agents.document_agent import DocumentAgent
+from app.agents.orchestrator import OrchestratorService, document_query_flow
+
+
+def test_orchestrator_routes_document_tasks() -> None:
+    """The orchestrator should delegate document queries to the document agent."""
+
+    query_function = MagicMock(return_value="respuesta contextual")
+    orchestrator = OrchestratorService(agents=[DocumentAgent(query_function=query_function)])
+
+    response = orchestrator.execute(
+        AgentTask(task_type="document_query", payload={"question": "¿Qué es PBC?"})
+    )
+
+    assert response.success is True
+    assert response.data == {"answer": "respuesta contextual"}
+    query_function.assert_called_once_with("¿Qué es PBC?", None)
+
+
+def test_orchestrator_returns_error_for_unknown_tasks() -> None:
+    """If no agent can handle the request, the orchestrator returns a controlled error."""
+
+    orchestrator = OrchestratorService(agents=[DocumentAgent(query_function=lambda *_: "irrelevant")])
+
+    response = orchestrator.execute(AgentTask(task_type="media_transcription", payload={}))
+
+    assert response.success is False
+    assert response.error == "no_agent_for_media_transcription"
+
+
+def test_document_agent_requires_question() -> None:
+    """Document agent should guard against empty payloads."""
+
+    agent = DocumentAgent(query_function=lambda *_: "unused")
+
+    response = agent.handle(AgentTask(task_type="document_query", payload={}))
+
+    assert response.success is False
+    assert response.error == "question_missing"
+
+
+def test_document_flow_helper_uses_provided_orchestrator() -> None:
+    """The helper flow should leverage any orchestrator injected for testing purposes."""
+
+    query_function = MagicMock(return_value="respuesta orquestada")
+    orchestrator = OrchestratorService(agents=[DocumentAgent(query_function=query_function)])
+
+    response = document_query_flow("Explica el cubo de datos", orchestrator=orchestrator)
+
+    assert response.success is True
+    assert response.data == {"answer": "respuesta orquestada"}
+    query_function.assert_called_once_with("Explica el cubo de datos", None)


### PR DESCRIPTION
## Summary
- scaffold a dedicated `app/agents` package with shared contracts, document/media agents and orchestrator utilities wired to the LangChain RAG core
- expose example document query flow plus helpers for building default orchestrators
- add orchestration delegation tests and ensure the FastAPI endpoints import all required utilities

## Testing
- pytest tests/agents/test_orchestrator.py
- pytest *(fails: existing suite depends on external LangChain/LangSmith stack and API auth configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d0233ba15c8320835f81ab6eae367d