### PR TITLE
Replace conversor page screenshot with textual diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ La aplicación se ejecuta en <http://localhost:8080> y la API REST está disponi
 - Gestión de documentos (ver y eliminar)
 - Endpoints para integraciones externas (consultas, ingestión y listado de archivos)
 
+### Descripción textual de la interfaz principal
+
+![Diagrama textual de la vista de conversación](docs/images/conversor_page.svg)
+
+- **Barra lateral**: muestra el título de la aplicación y el selector de idioma. Al cambiar la opción se actualizan los textos y prompts en tiempo real.
+- **Panel de conversación**: conserva el historial de mensajes del usuario y del asistente, con indicadores de carga mientras se generan las respuestas.
+- **Entrada del chat**: campo fijado en la parte inferior que valida mensajes vacíos o con más de 1000 caracteres antes de enviarlos.
+
 ### Ejemplos de uso de la API REST
 
 Consulta en español preservando acentos:

--- a/docs/images/conversor_page.svg
+++ b/docs/images/conversor_page.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="420" viewBox="0 0 720 420" role="img" aria-labelledby="title desc">
+  <title id="title">Diagrama textual de la interfaz de consulta de Anclora AI RAG</title>
+  <desc id="desc">
+    La ilustración describe la página principal de la aplicación. Muestra una barra lateral con el selector de idioma
+    y un panel principal que contiene el historial de mensajes y el cuadro de entrada del chat.
+  </desc>
+  <style>
+    text { font-family: 'Fira Sans', 'Segoe UI', Arial, sans-serif; fill: #1a1a1a; font-size: 14px; }
+    .title { font-size: 18px; font-weight: 600; }
+    .label { font-weight: 600; }
+    .note { font-size: 12px; fill: #444; }
+    .bullet { font-size: 12px; fill: #1a1a1a; }
+  </style>
+  <rect x="20" y="20" width="200" height="380" rx="12" ry="12" fill="#f0f4ff" stroke="#3b6bff" stroke-width="2"/>
+  <text x="30" y="50" class="title">Barra lateral</text>
+  <text x="30" y="80" class="label">Título</text>
+  <text x="30" y="100" class="bullet">• "Anclora AI RAG" visible en todo momento.</text>
+  <text x="30" y="130" class="label">Selector de idioma</text>
+  <text x="30" y="150" class="bullet">• Lista desplegable con opciones soportadas.</text>
+  <text x="30" y="170" class="bullet">• Ajusta textos y prompts dinámicamente.</text>
+  <text x="30" y="210" class="label">Acciones futuras</text>
+  <text x="30" y="230" class="note">Espacio reservado para atajos de carga o
+    indicadores de estado de la base de conocimiento.</text>
+
+  <rect x="240" y="20" width="460" height="260" rx="12" ry="12" fill="#ffffff" stroke="#00a39b" stroke-width="2"/>
+  <text x="255" y="50" class="title">Panel de conversación</text>
+  <text x="255" y="80" class="label">Historial</text>
+  <text x="255" y="100" class="bullet">• Burbujas alternadas para usuario y asistente.</text>
+  <text x="255" y="120" class="bullet">• Mensajes pasados se renderizan al recargar la página.</text>
+  <text x="255" y="150" class="label">Indicadores</text>
+  <text x="255" y="170" class="bullet">• Spinner de "procesando" durante la inferencia.</text>
+  <text x="255" y="190" class="bullet">• Alertas si el mensaje está vacío o excede 1000 caracteres.</text>
+
+  <rect x="240" y="300" width="460" height="100" rx="12" ry="12" fill="#f8f8f8" stroke="#888888" stroke-width="1.5"/>
+  <text x="255" y="330" class="title">Entrada del chat</text>
+  <text x="255" y="355" class="bullet">• Campo de texto persistente al pie de la ventana.</text>
+  <text x="255" y="375" class="bullet">• Envía la consulta cuando el usuario presiona Enter.</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the removed Conversor screenshot with a text-based SVG diagram of the chat UI
- describe the interface using the new textual resource in the README to avoid binary assets

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d02c3d2ea48320abe7dd5c607f6f32