### PR TITLE
Add marketing landing, feedback flow and launch checklist

### DIFF
--- a/docs/landing/assets/css/styles.css
+++ b/docs/landing/assets/css/styles.css
@@ -1,0 +1,398 @@
+:root {
+  --bg: #040b14;
+  --bg-soft: #0b1726;
+  --accent: #5f7bff;
+  --accent-soft: rgba(95, 123, 255, 0.15);
+  --text: #f9fbff;
+  --text-muted: #a9b6cc;
+  --surface: rgba(14, 29, 45, 0.85);
+  --border: rgba(255, 255, 255, 0.08);
+  --success: #36d399;
+  --error: #f87171;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(95, 123, 255, 0.08), transparent 55%), var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: var(--text);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--accent);
+}
+
+.container {
+  width: min(1120px, 92%);
+  margin: 0 auto;
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(16px);
+  background: rgba(4, 11, 20, 0.9);
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+}
+
+.logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, var(--accent), #8c4fff);
+  color: #fff;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 35px rgba(95, 123, 255, 0.22);
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+}
+
+.btn-outline {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: none;
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+}
+
+.hero__content {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero__copy h1 {
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  margin-bottom: 1rem;
+}
+
+.hero__copy p {
+  color: var(--text-muted);
+  max-width: 540px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--accent-soft);
+  border: 1px solid rgba(95, 123, 255, 0.4);
+  color: var(--accent);
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.8rem;
+  margin-bottom: 1.5rem;
+}
+
+.trust-signals {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--text-muted);
+}
+
+.hero__card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2rem;
+  backdrop-filter: blur(20px);
+}
+
+.metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.metric__value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.metric__label {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.card-text {
+  margin-top: 1.5rem;
+  color: var(--text-muted);
+}
+
+.social-proof {
+  padding: 2.5rem 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: rgba(10, 20, 32, 0.5);
+  text-align: center;
+}
+
+.social-proof p {
+  color: var(--text-muted);
+  margin-bottom: 1rem;
+}
+
+.social-proof .logos {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+}
+
+.benefits {
+  padding: 5rem 0;
+}
+
+.benefits .grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: rgba(10, 19, 31, 0.8);
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+  border-radius: 18px;
+  transition: border 0.2s ease, transform 0.2s ease;
+}
+
+.card:hover {
+  border-color: rgba(95, 123, 255, 0.6);
+  transform: translateY(-4px);
+}
+
+.workflow {
+  padding: 5rem 0;
+  background: linear-gradient(180deg, rgba(10, 19, 31, 0.9), rgba(10, 19, 31, 0.5));
+}
+
+.workflow__steps {
+  list-style: none;
+  padding: 0;
+  margin: 3rem 0 0;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.workflow__steps li {
+  background: rgba(6, 14, 24, 0.8);
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  border-radius: 16px;
+  position: relative;
+  min-height: 200px;
+}
+
+.step-number {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  border-radius: 50%;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.demo {
+  padding: 5rem 0;
+}
+
+.demo__content {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.form {
+  background: rgba(7, 16, 28, 0.85);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.form--inline {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.form__label {
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.form__input,
+.form textarea,
+.form select {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(2, 10, 22, 0.7);
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.form__input:focus,
+.form textarea:focus,
+.form select:focus {
+  outline: 2px solid rgba(95, 123, 255, 0.5);
+}
+
+.form__success,
+.form__error {
+  display: none;
+  font-size: 0.85rem;
+}
+
+.form__success {
+  color: var(--success);
+}
+
+.form__error {
+  color: var(--error);
+}
+
+.hidden {
+  display: none;
+}
+
+.beta {
+  padding: 4rem 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: rgba(6, 15, 27, 0.8);
+}
+
+.beta__content {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.feedback {
+  padding: 5rem 0;
+}
+
+.faq {
+  padding: 5rem 0 6rem;
+}
+
+.faq__item {
+  background: rgba(7, 16, 28, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.footer {
+  border-top: 1px solid var(--border);
+  background: rgba(3, 10, 20, 0.9);
+  padding: 2.5rem 0 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.footer__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.footer__links {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer__legal {
+  margin-top: 1.5rem;
+  font-size: 0.8rem;
+}
+
+@media (min-width: 768px) {
+  .footer__content {
+    flex-direction: row;
+    justify-content: space-between;
+    text-align: left;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav {
+    display: none;
+  }
+
+  .topbar .container {
+    justify-content: space-between;
+  }
+}

--- a/docs/landing/assets/js/feedback.js
+++ b/docs/landing/assets/js/feedback.js
@@ -1,0 +1,56 @@
+(function () {
+  const forms = document.querySelectorAll('form[data-netlify="true"]');
+
+  const encode = (data) =>
+    Object.keys(data)
+      .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(data[key])}`)
+      .join('&');
+
+  forms.forEach((form) => {
+    const success = form.querySelector('[data-success]');
+    const error = form.querySelector('[data-error]');
+
+    if (success) success.style.display = 'none';
+    if (error) error.style.display = 'none';
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const data = {};
+      formData.forEach((value, key) => {
+        data[key] = value;
+      });
+
+      try {
+        await fetch('/', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: encode(data),
+        });
+
+        if (success) {
+          success.style.display = 'block';
+          success.setAttribute('role', 'status');
+        }
+        if (error) {
+          error.style.display = 'none';
+        }
+        form.reset();
+
+        if (window.plausible) {
+          const eventName = form.getAttribute('name') || 'form-submit';
+          window.plausible('Formulario enviado', { props: { form: eventName } });
+        }
+      } catch (err) {
+        console.error('Error submitting Netlify form', err);
+        if (error) {
+          error.style.display = 'block';
+          error.setAttribute('role', 'alert');
+        }
+        if (success) {
+          success.style.display = 'none';
+        }
+      }
+    });
+  });
+})();

--- a/docs/landing/feedback-flow.md
+++ b/docs/landing/feedback-flow.md
@@ -1,0 +1,66 @@
+# Flujo de feedback y analítica ligera
+
+Este documento describe cómo se gestionan los formularios y el seguimiento de interacción en la landing page de Anclora AI (`docs/landing/`).
+
+## Formularios habilitados
+
+La landing incluye tres formularios basados en [Netlify Forms](https://docs.netlify.com/forms/setup/):
+
+1. **`demo-form`** – Solicitudes de demostración y evaluación de piloto.
+2. **`waitlist-form`** – Lista de espera para actualizaciones de producto y lanzamientos.
+3. **`feedback-form`** – Investigación de necesidades y descubrimiento de problemas.
+
+Cada formulario:
+
+- Usa la propiedad `data-netlify="true"` para que Netlify capture los envíos.
+- Incluye un `honeypot` (`bot-field`) para reducir spam automatizado.
+- Muestra mensajes de éxito/error gestionados en `assets/js/feedback.js`.
+
+### Flujo operativo sugerido
+
+1. **Publicación en Netlify**
+   - Desplegar el sitio estático (`docs/landing/`) en un sitio Netlify (por ejemplo `landing.anclora.ai`).
+   - Mantener activada la opción *Forms* en la configuración del proyecto.
+
+2. **Almacenamiento y notificaciones**
+   - En Netlify, activar notificaciones por correo a `growth@anclora.ai` para cada nuevo envío.
+   - Configurar un _outgoing webhook_ hacia el endpoint de automatización de Slack (`https://hooks.slack.com/services/...`) para avisar en el canal `#anclora-leads`.
+   - Conectar la integración con Airtable/Notion mediante Zapier o n8n para registrar los campos clave (`name`, `email`, `company`, `volume`, `message`).
+
+3. **Asignación de responsables**
+   - **Ventas (demo-form):** el equipo comercial recibe alertas y debe contactar en < 24 h.
+   - **Producto (feedback-form):** el equipo de producto clasifica la retroalimentación semanalmente y la etiqueta según tipo de desafío.
+   - **Marketing (waitlist-form):** marketing alimenta una secuencia de correos (bienvenida, roadmap, invitaciones a webinars).
+
+### Manejo de errores
+
+Si Netlify no está disponible, el script `feedback.js` muestra el mensaje de error con la dirección de contacto correspondiente para que la persona usuaria pueda escribir directamente.
+
+## Analítica ligera
+
+Se utiliza [Plausible Analytics](https://plausible.io/) con el script `script.manual.pageview-props.js`, configurado con el dominio `landing.anclora.ai`.
+
+### Eventos capturados
+
+- **Pageview** manual: el script puede invocarse desde `feedback.js` (ejemplo de evento personalizado `Formulario enviado`).
+- **Formularios**: al completarse un formulario, se dispara `window.plausible('Formulario enviado', { props: { form: '<nombre>' } })` para segmentar conversiones.
+
+### Recomendaciones de privacidad
+
+- Activar la opción *Self-Hosted Proxy* de Plausible o usar el proxy oficial para cumplir con GDPR.
+- Actualizar la política de privacidad con el detalle de uso de formularios y analítica.
+
+## Monitoreo de métricas
+
+| Métrica | Fuente | Frecuencia | Responsable |
+| --- | --- | --- | --- |
+| Conversiones demo | Evento Plausible `Formulario enviado` (prop `demo-form`) | Semanal | Ventas |
+| Nuevos leads lista de espera | Netlify + CRM | Diario | Marketing |
+| Feedback cualitativo | Exportación Netlify → Notion | Quincenal | Producto |
+| Fallos de formulario | Alertas Netlify (webhook) | En tiempo real | Ingeniería |
+
+## Próximos pasos sugeridos
+
+- Conectar Plausible con el dashboard ejecutivo ya utilizado por el equipo.
+- Evaluar herramientas complementarias (Hotjar, LogRocket) solo si se mantiene el enfoque en privacidad.
+- Añadir tracking de CTA secundarias mediante atributos `data-analytics` y eventos manuales.

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anclora AI | Convierte 1000 archivos en conocimiento accionable</title>
+    <meta
+      name="description"
+      content="Convierte 1000 archivos en conocimiento accionable con IA generativa. Automatiza ingestión, orquestación y monitorización de pipelines RAG para tu empresa."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./assets/css/styles.css" />
+    <script defer src="./assets/js/feedback.js"></script>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="container">
+        <div class="logo">Anclora AI</div>
+        <nav class="nav">
+          <a href="#beneficios">Beneficios</a>
+          <a href="#flujo">Cómo funciona</a>
+          <a href="#feedback">Feedback</a>
+          <a href="#faq">FAQ</a>
+        </nav>
+        <a class="btn btn-outline" href="#demo">Solicita demo</a>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero" id="hero">
+        <div class="container hero__content">
+          <div class="hero__copy">
+            <span class="pill">Nueva generación RAG Ops</span>
+            <h1>Convierte 1000 archivos en conocimiento accionable con IA generativa</h1>
+            <p>
+              Anclora automatiza la ingesta, limpieza y orquestación de tus repositorios de
+              conocimiento para que tus equipos lancen asistentes de IA confiables en días, no meses.
+            </p>
+            <div class="cta-group">
+              <a class="btn" href="#demo">Agenda una demo</a>
+              <a class="btn btn-outline" href="#beta">Únete a la lista de espera</a>
+            </div>
+            <ul class="trust-signals">
+              <li>Procesa documentos multiformato (PDF, Office, Markdown, HTML, audio)</li>
+              <li>Automatiza pipelines RAG con monitoreo y alertas integradas</li>
+              <li>Cumplimiento y seguridad listas para auditorías</li>
+            </ul>
+          </div>
+          <div class="hero__card">
+            <div class="metrics">
+              <div class="metric">
+                <span class="metric__value">98%</span>
+                <span class="metric__label">de precisión validada</span>
+              </div>
+              <div class="metric">
+                <span class="metric__value">10x</span>
+                <span class="metric__label">reducción de tiempo de despliegue</span>
+              </div>
+              <div class="metric">
+                <span class="metric__value">5 min</span>
+                <span class="metric__label">para monitorear la salud del pipeline</span>
+              </div>
+            </div>
+            <p class="card-text">
+              Consolida el control de tus fuentes, evalúa calidad y haz tuning continuo desde una
+              sola plataforma.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="social-proof">
+        <div class="container">
+          <p>Equipos de data, CX y compliance ya confían en Anclora</p>
+          <div class="logos">
+            <span>Fintech LatAm</span>
+            <span>Retail360</span>
+            <span>Salud IA</span>
+            <span>Universidad X</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="benefits" id="beneficios">
+        <div class="container">
+          <h2>Todo lo que necesitas para operar RAG a escala</h2>
+          <div class="grid">
+            <article class="card">
+              <h3>Pipeline listo en horas</h3>
+              <p>
+                Conectores listos para SharePoint, Notion, S3, bases de datos SQL/NoSQL y APIs.
+                Deduplica, limpia y clasifica tu contenido automáticamente.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Observabilidad en tiempo real</h3>
+              <p>
+                Dashboards de calidad, trazabilidad de respuestas y alertas de regresión para que tu
+                copiloto nunca falle.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Seguridad de nivel empresarial</h3>
+              <p>
+                Controles RBAC, cifrado end-to-end y despliegue híbrido para cumplir con GDPR y
+                normativas locales.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Playbooks de adopción</h3>
+              <p>
+                Sesiones asistidas, documentación lista y métricas de impacto para demostrar valor en
+                el primer trimestre.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="workflow" id="flujo">
+        <div class="container">
+          <h2>Un flujo continuo de valor</h2>
+          <ol class="workflow__steps">
+            <li>
+              <span class="step-number">1</span>
+              <h3>Mapea y prioriza tus fuentes</h3>
+              <p>Identificamos repositorios críticos y definimos políticas de refresco.</p>
+            </li>
+            <li>
+              <span class="step-number">2</span>
+              <h3>Ingesta automatizada</h3>
+              <p>Conectores seguros con transformación y enriquecimiento semántico.</p>
+            </li>
+            <li>
+              <span class="step-number">3</span>
+              <h3>Evaluación continua</h3>
+              <p>Benchmarks, anotaciones humanas y métricas listas para auditorías.</p>
+            </li>
+            <li>
+              <span class="step-number">4</span>
+              <h3>Monitorización y alertas</h3>
+              <p>Detección automática de drift y respuestas fuera de política.</p>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section class="demo" id="demo">
+        <div class="container demo__content">
+          <div class="demo__copy">
+            <h2>Lanza pilotos en semanas, escala en producción con confianza</h2>
+            <p>
+              Coordina una sesión personalizada para mapear tus casos de uso, definir métricas clave y
+              comenzar con un plan de onboarding de 30 días.
+            </p>
+            <ul>
+              <li>Diagnóstico de fuentes y políticas de seguridad</li>
+              <li>Configuración guiada del pipeline y dashboards</li>
+              <li>Plan de habilitación y entrenamiento de equipos</li>
+            </ul>
+          </div>
+          <form
+            class="form"
+            id="demo-form"
+            name="demo-form"
+            method="POST"
+            data-netlify="true"
+            netlify-honeypot="bot-field"
+          >
+            <input type="hidden" name="form-name" value="demo-form" />
+            <p class="hidden">
+              <label>
+                No llenar:
+                <input name="bot-field" />
+              </label>
+            </p>
+            <label class="form__label" for="demo-name">Nombre</label>
+            <input class="form__input" type="text" id="demo-name" name="name" required />
+
+            <label class="form__label" for="demo-email">Correo profesional</label>
+            <input class="form__input" type="email" id="demo-email" name="email" required />
+
+            <label class="form__label" for="demo-company">Empresa</label>
+            <input class="form__input" type="text" id="demo-company" name="company" required />
+
+            <label class="form__label" for="demo-volume">Volumen de documentos mensual</label>
+            <select class="form__input" id="demo-volume" name="volume" required>
+              <option value="">Selecciona una opción</option>
+              <option value="0-1k">Hasta 1.000</option>
+              <option value="1k-10k">1.000 - 10.000</option>
+              <option value="10k-100k">10.000 - 100.000</option>
+              <option value="100k+">Más de 100.000</option>
+            </select>
+
+            <label class="form__label" for="demo-message">¿Qué quieres lograr con Anclora?</label>
+            <textarea
+              class="form__input"
+              id="demo-message"
+              name="message"
+              rows="4"
+              placeholder="Ej. reducir tiempo de respuesta del equipo legal"
+              required
+            ></textarea>
+
+            <button class="btn" type="submit">Solicitar demo</button>
+            <p class="form__success" data-success>¡Gracias! Te contactaremos en menos de 24 horas.</p>
+            <p class="form__error" data-error>
+              Ocurrió un problema. Escríbenos a <a href="mailto:hola@anclora.ai">hola@anclora.ai</a>.
+            </p>
+          </form>
+        </div>
+      </section>
+
+      <section class="beta" id="beta">
+        <div class="container beta__content">
+          <div>
+            <h2>Inscríbete en la lista de espera</h2>
+            <p>
+              Recibe actualizaciones de roadmap, invitaciones a sesiones en vivo y acceso temprano a
+              nuevas integraciones.
+            </p>
+          </div>
+          <form
+            class="form form--inline"
+            id="waitlist-form"
+            name="waitlist-form"
+            method="POST"
+            data-netlify="true"
+            netlify-honeypot="bot-field"
+          >
+            <input type="hidden" name="form-name" value="waitlist-form" />
+            <label class="hidden" for="waitlist-name">Nombre</label>
+            <input
+              class="form__input"
+              type="text"
+              id="waitlist-name"
+              name="name"
+              placeholder="Tu nombre"
+              required
+            />
+            <label class="hidden" for="waitlist-email">Correo profesional</label>
+            <input
+              class="form__input"
+              type="email"
+              id="waitlist-email"
+              name="email"
+              placeholder="tu@empresa.com"
+              required
+            />
+            <button class="btn" type="submit">Unirme</button>
+            <p class="form__success" data-success>¡Listo! Revisa tu correo para confirmar.</p>
+            <p class="form__error" data-error>
+              No pudimos registrar tu correo. Escríbenos a
+              <a href="mailto:hola@anclora.ai">hola@anclora.ai</a>.
+            </p>
+          </form>
+        </div>
+      </section>
+
+      <section class="feedback" id="feedback">
+        <div class="container">
+          <h2>Tu retroalimentación es clave</h2>
+          <p>
+            Cuéntanos sobre tu experiencia con asistentes RAG y qué funcionalidades necesitas para
+            adoptarlos con confianza.
+          </p>
+          <form
+            class="form"
+            id="feedback-form"
+            name="feedback-form"
+            method="POST"
+            data-netlify="true"
+            netlify-honeypot="bot-field"
+          >
+            <input type="hidden" name="form-name" value="feedback-form" />
+            <p class="hidden">
+              <label>
+                No llenar:
+                <input name="bot-field" />
+              </label>
+            </p>
+            <label class="form__label" for="feedback-role">Rol</label>
+            <select class="form__input" id="feedback-role" name="role" required>
+              <option value="">Selecciona tu rol</option>
+              <option value="data">Data / Analytics</option>
+              <option value="it">IT / Infraestructura</option>
+              <option value="product">Producto / Innovación</option>
+              <option value="compliance">Compliance / Legal</option>
+              <option value="other">Otro</option>
+            </select>
+
+            <label class="form__label" for="feedback-challenge">Mayor desafío hoy</label>
+            <textarea
+              class="form__input"
+              id="feedback-challenge"
+              name="challenge"
+              rows="3"
+              required
+            ></textarea>
+
+            <label class="form__label" for="feedback-impact">Impacto esperado</label>
+            <textarea
+              class="form__input"
+              id="feedback-impact"
+              name="impact"
+              rows="3"
+              required
+            ></textarea>
+
+            <label class="form__label" for="feedback-contact">¿Quieres participar en research?</label>
+            <select class="form__input" id="feedback-contact" name="research" required>
+              <option value="">Selecciona una opción</option>
+              <option value="yes">Sí, quiero agendar una entrevista</option>
+              <option value="maybe">Tal vez más adelante</option>
+              <option value="no">No por ahora</option>
+            </select>
+
+            <button class="btn" type="submit">Enviar feedback</button>
+            <p class="form__success" data-success>¡Gracias por tu feedback!</p>
+            <p class="form__error" data-error>
+              Ocurrió un problema. Escríbenos a <a href="mailto:research@anclora.ai">research@anclora.ai</a>.
+            </p>
+          </form>
+        </div>
+      </section>
+
+      <section class="faq" id="faq">
+        <div class="container">
+          <h2>Preguntas frecuentes</h2>
+          <div class="faq__item">
+            <h3>¿Qué hace diferente a Anclora de otras plataformas RAG?</h3>
+            <p>
+              Diseñamos la plataforma para equipos altamente regulados. Nuestro enfoque combina
+              curación automática, evaluación humana asistida y observabilidad nativa.
+            </p>
+          </div>
+          <div class="faq__item">
+            <h3>¿Puedo desplegarlo en mi propia nube?</h3>
+            <p>
+              Sí. Ofrecemos despliegues gestionados, híbridos y on-premise para cumplir requisitos de
+              soberanía de datos.
+            </p>
+          </div>
+          <div class="faq__item">
+            <h3>¿Qué modelos de lenguaje soportan?</h3>
+            <p>
+              Trabajamos con proveedores líderes (OpenAI, Anthropic, Azure OpenAI) y modelos open
+              source optimizados para cada caso de uso.
+            </p>
+          </div>
+          <div class="faq__item">
+            <h3>¿Cómo se mide el ROI?</h3>
+            <p>
+              Configuramos métricas personalizadas de productividad, satisfacción y ahorro en tickets
+              desde el primer mes de operación.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer__content">
+        <div>
+          <div class="logo">Anclora AI</div>
+          <p>IA generativa operable y segura para equipos exigentes.</p>
+        </div>
+        <div class="footer__links">
+          <a href="mailto:hola@anclora.ai">Contacto</a>
+          <a href="https://www.linkedin.com/company/anclora-ai" target="_blank" rel="noreferrer"
+            >LinkedIn</a
+          >
+          <a href="https://cal.com/anclora" target="_blank" rel="noreferrer">Agenda</a>
+        </div>
+      </div>
+      <p class="footer__legal">© <span id="current-year"></span> Anclora AI. Todos los derechos reservados.</p>
+    </footer>
+
+    <script>
+      document.getElementById("current-year").textContent = new Date().getFullYear();
+    </script>
+    <script
+      defer
+      data-domain="landing.anclora.ai"
+      src="https://plausible.io/js/script.manual.pageview-props.js"
+    ></script>
+  </body>
+</html>

--- a/docs/landing/roadmap-comunicacion.md
+++ b/docs/landing/roadmap-comunicacion.md
@@ -1,0 +1,85 @@
+# Plan de comunicación de roadmap y coordinación de publicación
+
+Este plan alinea las acciones de lanzamiento de la landing con la comunicación proactiva del roadmap a la comunidad interesada.
+
+## Objetivos
+
+1. **Generar adopción temprana** del producto mediante convocatorias claras a demos y lista de espera.
+2. **Mantener informados a los interesados** sobre nuevas funcionalidades, integraciones y hitos de producto.
+3. **Construir confianza** demostrando transparencia en prioridades, fechas estimadas y canales de soporte.
+
+## Cronograma
+
+| Hito | Fecha estimada | Responsable | Descripción |
+| --- | --- | --- | --- |
+| Freeze de contenido | T-10 días | Marketing + Producto | Validar copy final, FAQ y assets visuales. |
+| Publicación landing | Día 0 | Ingeniería + Marketing | Deploy en Netlify + verificación de formularios y analytics. |
+| Email a interesados | Día 0 | Marketing | Enviar correo a contactos existentes con anuncio y CTA a demo/lista de espera. |
+| Sesión roadmap live | Día 2 | Producto + Customer Success | Webinar de 30 min para interesados registrados. |
+| Recordatorio de feedback | Día 7 | Producto | Email automatizado solicitando completar formulario de feedback. |
+| Reporte de resultados iniciales | Día 14 | Marketing | Compartir métricas clave y próximos pasos a base de interesados. |
+
+## Piezas de comunicación
+
+### 1. Email de anuncio (Día 0)
+
+- Asunto sugerido: `Ya puedes convertir 1000 archivos en conocimiento accionable con Anclora`.
+- Contenido:
+  - Breve resumen del valor diferencial.
+  - Enlaces directos a demo y lista de espera.
+  - Botón “Explorar roadmap” que dirige a una sección Notion con próximos hitos.
+
+### 2. Post en LinkedIn
+
+- Copy clave: destacar la eficiencia (`10x reducción de tiempo`), la seguridad y el acompañamiento.
+- CTA: link a la landing y mención de la sesión roadmap.
+
+### 3. Webinar/Sesión roadmap
+
+- Plataforma sugerida: Livestorm o Zoom.
+- Agenda:
+  1. Retos actuales para operar RAG.
+  2. Demo rápida de la plataforma.
+  3. Roadmap Q3-Q4 (integraciones, observabilidad avanzada, compliance packs).
+  4. Espacio de preguntas.
+- Seguimiento: enviar resumen + grabación a asistentes y a quienes no pudieron asistir.
+
+### 4. Secuencia de nurtures (Lista de espera)
+
+1. **Bienvenida (inmediato):** reiterar valor, enlazar a la landing y proponer agendar demo.
+2. **Roadmap detallado (Día 3):** tabla con próximos lanzamientos, fechas estimadas y estatus.
+3. **Casos de uso (Día 10):** historias breves de sectores (finanzas, retail, educación).
+4. **Invitación a prueba piloto (Día 21):** requisitos para participar y formulario prioritario.
+
+### 5. Actualizaciones continuas
+
+- Publicar changelog mensual en Notion/Blog.
+- Enviar resumen trimestral a la lista de espera destacando hitos cumplidos y próximos objetivos.
+
+## Coordinación interna
+
+- **Marketing:** responsable del calendario editorial y de ejecutar emails/posts.
+- **Producto:** prepara contenido de roadmap y gestiona feedback de usuarios.
+- **Customer Success:** organiza sesiones live y da seguimiento personalizado a cuentas estratégicas.
+- **Ingeniería:** garantiza estabilidad del sitio y soporte técnico durante el lanzamiento.
+
+## Métricas de éxito
+
+| Métrica | Meta | Fuente |
+| --- | --- | --- |
+| Tasa de apertura email lanzamiento | ≥ 45% | Herramienta de email marketing |
+| Registro a sesión roadmap | 30% de la lista de interesados | Landing + herramienta webinar |
+| Conversiones a demo | ≥ 15 reuniones agendadas en 30 días | Cal.com / CRM |
+| Feedback cualitativo recibido | ≥ 20 respuestas detalladas | Netlify Forms + Notion |
+
+## Riesgos y mitigaciones
+
+- **Sobrecarga de mensajes:** espaciar las comunicaciones y personalizar según segmento.
+- **Promesas de roadmap no cumplidas:** definir claramente hitos `Committed` vs `Exploratory`.
+- **Baja asistencia a webinar:** ofrecer diferentes horarios y enviar recordatorios (24h y 1h antes).
+
+## Repositorios y recursos
+
+- Plantillas de correo: `docs/templates/emails-roadmap/` (crear en próxima iteración).
+- Registro central de interesados: Base en Notion `Clientes potenciales`.
+- Calendario maestro: Google Calendar compartido `Go-to-market`.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,58 @@
+# Checklist de lanzamiento de la landing Anclora AI
+
+> Objetivo: lanzar la landing (`docs/landing/`) en producción, habilitar feedback y monitorear rendimiento durante las primeras 4 semanas.
+
+## 1. Preparación (T-14 días)
+
+- [ ] Revisar copy y claims con equipo legal y compliance.
+- [ ] Validar assets visuales (logo, colores, fuentes) con branding.
+- [ ] Actualizar enlaces externos (LinkedIn, Calendario, Email) y verificar que estén activos.
+- [ ] Configurar dominio `landing.anclora.ai` y certificado SSL.
+- [ ] Aprobar política de privacidad y aviso de cookies actualizado.
+- [ ] Confirmar responsables de seguimiento (Marketing, Producto, Ventas, Ingeniería).
+
+## 2. QA previo al despliegue (T-7 días)
+
+- [ ] Pruebas de visualización en navegadores clave (Chrome, Firefox, Safari, Edge) y mobile.
+- [ ] Validar tiempos de carga (< 2.5s LCP en conexiones 4G) usando Lighthouse.
+- [ ] Probar envíos de formularios `demo-form`, `waitlist-form` y `feedback-form` en entorno de staging.
+- [ ] Confirmar recepción de notificaciones en correo, Slack y CRM.
+- [ ] Revisar que los eventos de Plausible se registren correctamente.
+- [ ] Ejecutar checklist de accesibilidad (contrast ratio, labels, navegación con teclado).
+
+## 3. Go-Live (Día 0)
+
+- [ ] Publicar la landing en Netlify o infraestructura elegida.
+- [ ] Activar redirecciones necesarias (ej. `/beta`, `/demo`).
+- [ ] Anunciar internamente (Slack/Notion) que la landing está en producción.
+- [ ] Programar recordatorios diarios para revisar formularios durante la semana de lanzamiento.
+- [ ] Hacer _smoke test_ post-deploy (carga, CTA, formularios, analytics).
+
+## 4. Comunicación externa
+
+- [ ] Enviar correo a lista de interesados con resumen del roadmap (ver plan en `docs/landing/roadmap-comunicacion.md`).
+- [ ] Publicar anuncio en LinkedIn y Twitter corporativo.
+- [ ] Compartir la landing con partners estratégicos y solicitar retroalimentación.
+- [ ] Coordinar participación en comunidades relevantes (ej. Latam Startups, Product Hackers).
+
+## 5. Monitoreo post-release (Semana 1-4)
+
+- [ ] Revisar diariamente métricas clave (visitas únicas, conversiones demo, lista de espera).
+- [ ] Analizar feedback cualitativo y generar insights semanales.
+- [ ] Ajustar copy o secciones con base en comportamiento (scroll depth, heatmaps si aplica).
+- [ ] Confirmar que no existan errores 404/500 mediante monitoreo de uptime (StatusCake/UptimeRobot).
+- [ ] Actualizar dashboard de métricas compartido con stakeholders.
+- [ ] Preparar informe de impacto al cierre de la semana 4.
+
+## 6. Retrospectiva y siguientes iteraciones (Semana 5)
+
+- [ ] Realizar retro con equipos involucrados (Marketing, Producto, Ventas, Ingeniería).
+- [ ] Priorizar mejoras detectadas en backlog (`docs/backlog.md`).
+- [ ] Documentar aprendizajes y actualizar checklist para próximos lanzamientos.
+
+---
+
+**Notas adicionales**
+
+- Mantener evidencia de aprobaciones en Notion o GDrive.
+- Documentar cualquier excepción o riesgo identificado durante el proceso.


### PR DESCRIPTION
## Summary
- create a marketing landing page under `docs/landing/` with hero copy "Convierte 1000 archivos en conocimiento accionable" and sections for beneficios, demo, feedback y FAQ
- add Netlify-compatible forms, lightweight Plausible analytics hook and document the feedback/analytics flow
- plan release, communication and monitoring tasks in `docs/release-checklist.md` and roadmap communication plan

## Testing
- no automated tests were run (documentation and static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d02c1420248320b5f55844b211ae0b