### PR TITLE
Add legal documentation for conversions and privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ El detalle de fases, épicas y tareas priorizadas se encuentra en el [backlog de
 
 - [Guía de Integración / Integration Guide](docs/integration-guide.md): Pasos para consumir la API, usar el cliente Python oficial y conectar agentes (LangChain, AutoGen) con recomendaciones de encoding y manejo de Unicode.
 
+### Información legal y cumplimiento
+
+- [Términos y Condiciones de Uso](docs/legal/terms.md): reglas de uso de la plataforma, política de consentimiento y proceso de verificación de derechos antes de cada conversión.
+- [Política de Privacidad](docs/legal/privacy.md): tratamiento de datos personales, conservación de evidencias de consentimiento y medidas de seguridad recomendadas.
+
 ### Uso
 
 La aplicación se ejecuta en <http://localhost:8080> y la API REST está disponible en <http://localhost:8081>. Desde la UI y la API se ofrece:

--- a/docs/landing-page.md
+++ b/docs/landing-page.md
@@ -1,0 +1,20 @@
+# Borrador de Contenido para la Landing Page
+
+Este borrador documenta los componentes mínimos que deberá incluir la futura landing page pública de Anclora AI RAG. Sirve como guía para el equipo de producto, marketing y legal antes del desarrollo frontend definitivo.
+
+## Secciones clave
+
+1. **Hero**: mensaje principal sobre automatización de flujos documentales con IA y llamada a la acción para solicitar acceso.
+2. **Características**: resumen de ingesta de documentos, asesor de conversiones y controles de cumplimiento.
+3. **Casos de uso**: archivado, publicación web accesible, distribución multiformato.
+4. **Cumplimiento y confianza**: destacar políticas internas, auditorías y responsabilidad sobre derechos.
+5. **Llamado a la acción secundario**: formulario de contacto o suscripción a lista de espera.
+
+## Recursos legales obligatorios
+
+Incluir en el pie de página o sección de cumplimiento enlaces visibles a los siguientes documentos:
+
+- [Términos y Condiciones de Uso](docs/legal/terms.md)
+- [Política de Privacidad](docs/legal/privacy.md)
+
+La redacción final deberá revisarse con asesoría legal antes del lanzamiento para asegurar coherencia con la funcionalidad disponible en producción.

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,67 @@
+# Política de Privacidad
+
+## 1. Responsable del tratamiento
+Anclora AI ("la Plataforma") actúa como responsable del tratamiento respecto de los datos personales tratados mediante los servicios de conversión y consulta. Para contactarnos, escribir a privacy@anclora.ai.
+
+## 2. Datos recopilados
+Dependiendo de las funcionalidades utilizadas, la Plataforma puede tratar:
+
+- Datos de contacto para crear cuentas y gestionar acceso.
+- Metadatos técnicos necesarios para operar los servicios (direcciones IP, registros de actividad, identificadores de sesión).
+- Contenido de los documentos cargados para ejecutar consultas y conversiones.
+- Evidencia de consentimientos y verificaciones de derechos previos a cada conversión.
+
+La Plataforma recomienda anonimizar o seudonimizar los documentos antes de subirlos cuando sea posible.
+
+## 3. Finalidades del tratamiento
+Los datos se emplean para:
+
+1. Prestar los servicios de consulta y conversión solicitados.
+2. Realizar verificaciones de derechos de autor y consentimientos previos conforme a la política descrita en estos documentos.
+3. Mejorar la calidad del servicio mediante métricas agregadas y sin identificación personal.
+4. Cumplir obligaciones legales y atender requerimientos de autoridades competentes.
+
+No se utilizarán los datos para fines distintos a los aquí descritos sin obtener un consentimiento adicional.
+
+## 4. Consentimiento y base legal
+El tratamiento se sustenta en:
+
+- Consentimiento explícito de las personas usuarias y de las personas titulares de los documentos, cuando la normativa lo exige.
+- Ejecución de un contrato o relación jurídica con quien solicita el servicio.
+- Interés legítimo en garantizar la seguridad y funcionamiento de la Plataforma.
+
+Las personas usuarias deben documentar el consentimiento de las partes involucradas antes de cargar o convertir documentos. La Plataforma puede solicitar evidencias de dicha documentación en cualquier momento.
+
+## 5. Verificación de derechos y trazabilidad
+Previo a cada conversión se deberá:
+
+1. Confirmar la titularidad de los derechos sobre el documento o contar con licencias válidas.
+2. Registrar el consentimiento y los usos permitidos, especialmente cuando se involucren datos personales.
+3. Guardar registros de la evaluación realizada, incluyendo fecha, responsable y resultado.
+4. Conservar la versión original del documento y las conversiones generadas para auditoría.
+
+La Plataforma ofrece funcionalidades para adjuntar estos registros, pero la responsabilidad final recae en la persona usuaria.
+
+## 6. Conservación y eliminación
+Los datos se conservarán durante el tiempo estrictamente necesario para brindar los servicios o mientras exista una relación contractual. La persona usuaria puede solicitar la eliminación anticipada, siempre que no exista una obligación legal que requiera conservarlos.
+
+Los registros de consentimiento y verificación de derechos deben mantenerse conforme a los plazos legales aplicables en la jurisdicción correspondiente.
+
+## 7. Seguridad
+Se aplican medidas técnicas y organizativas razonables para proteger los datos frente a acceso no autorizado, pérdida o alteración. Esto incluye cifrado en tránsito, control de accesos basado en roles y monitoreo de eventos.
+
+En caso de incidentes de seguridad, se notificará a las personas afectadas y a las autoridades competentes según los plazos legales.
+
+## 8. Derechos de las personas usuarias
+Dependiendo de la normativa aplicable, las personas usuarias pueden ejercer los derechos de acceso, rectificación, cancelación, oposición, portabilidad y limitación del tratamiento. Las solicitudes deben dirigirse a privacy@anclora.ai e incluir información suficiente para validar la identidad.
+
+## 9. Transferencias a terceros
+Los datos no se comparten con terceros salvo que sea necesario para prestar el servicio (proveedores de infraestructura, almacenamiento o soporte) o cuando lo exija la ley. En dichos casos se firmarán acuerdos que garanticen un nivel de protección equivalente al previsto en esta Política.
+
+## 10. Modificaciones
+La Plataforma puede actualizar esta Política para reflejar cambios regulatorios o mejoras operativas. Las modificaciones se comunicarán a través de los canales habituales. El uso continuo de la Plataforma implica la aceptación de la versión vigente.
+
+## 11. Revisión legal
+Se recomienda revisar esta Política con asesoría legal especializada antes de cada publicación o despliegue en producción, a fin de garantizar su alineación con las leyes locales y sectoriales.
+
+Última actualización: {{FECHA_ACTUALIZACIÓN}}

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,49 @@
+# Términos y Condiciones de Uso
+
+## 1. Introducción
+Estos Términos y Condiciones regulan el acceso y uso de la plataforma Anclora AI RAG ("la Plataforma"), incluyendo sus herramientas de conversión documental y los servicios complementarios. Al acceder o utilizar la Plataforma, la persona usuaria acepta cumplir las cláusulas aquí descritas. Si no está de acuerdo, deberá abstenerse de utilizar la Plataforma.
+
+## 2. Alcance del servicio
+La Plataforma permite subir documentos, generar respuestas contextuales y solicitar conversiones asistidas mediante inteligencia artificial. Las funcionalidades pueden variar según la versión o plan habilitado.
+
+## 3. Propiedad intelectual y derechos de autor
+La persona usuaria manifiesta que posee o ha obtenido las licencias necesarias para los documentos que cargue en la Plataforma. Al utilizar los servicios, otorga a la Plataforma una licencia no exclusiva y limitada para procesar los archivos con el único fin de prestar el servicio solicitado.
+
+La Plataforma no adquiere derechos sobre el contenido original ni sobre las conversiones generadas. Las conversiones pertenecen a la persona usuaria o a quien corresponda conforme a la legislación aplicable. Se prohíbe utilizar la Plataforma para convertir o distribuir materiales que infrinjan derechos de autor, marcas, secretos comerciales u otros derechos de terceros.
+
+## 4. Uso permitido de conversiones
+Las conversiones producidas deben emplearse conforme a la normativa vigente y a los acuerdos contractuales que la persona usuaria tenga con las partes interesadas. Queda prohibido revender, licenciar o difundir conversiones cuando ello vulnere derechos ajenos o condiciones específicas de las fuentes originales.
+
+La persona usuaria es responsable de verificar que el uso previsto de las conversiones (archivado, publicación web, accesibilidad u otros) no infrinja restricciones legales o contractuales. La Plataforma puede incluir controles automatizados para advertir sobre riesgos, pero su uso no sustituye la debida diligencia humana.
+
+## 5. Política de consentimiento previo
+Antes de iniciar cualquier conversión, la persona usuaria debe contar con el consentimiento explícito de las personas autoras o titulares de los derechos, cuando la normativa lo requiera. El consentimiento debe documentarse e incluir el alcance del procesamiento, los formatos resultantes y los usos previstos.
+
+Cuando los documentos contengan datos personales, será necesario obtener los consentimientos adicionales exigidos por la legislación de protección de datos, garantizando que las finalidades informadas incluyan la conversión y el análisis con inteligencia artificial.
+
+## 6. Verificación de derechos previa a conversiones
+La Plataforma recomienda el siguiente proceso de verificación antes de ejecutar una conversión:
+
+1. Identificar la titularidad de cada documento y recopilar licencias o cesiones vigentes.
+2. Confirmar la existencia de restricciones contractuales, confidencialidad o clausulados que limiten la transformación del material.
+3. Documentar los consentimientos obtenidos y almacenarlos junto a la versión original.
+4. Registrar la finalidad de la conversión y evaluar si el uso previsto requiere autorizaciones adicionales.
+5. Validar que el resultado cumpla con los acuerdos alcanzados con autoras, titulares de datos y otras personas involucradas.
+
+La persona usuaria debe conservar evidencia de este proceso para atender auditorías, reclamos o solicitudes de las autoridades competentes.
+
+## 7. Responsabilidades de la persona usuaria
+- Garantizar que los contenidos proporcionados son lícitos y que su uso no vulnera derechos.
+- Configurar y monitorear las conversiones conforme a los estándares legales y contractuales aplicables.
+- Notificar oportunamente a la Plataforma sobre cualquier infracción detectada o reclamo recibido.
+
+## 8. Limitación de responsabilidad
+La Plataforma ofrece herramientas de apoyo basadas en reglas expertas y modelos de inteligencia artificial. No obstante, la validación final de cada conversión recae en la persona usuaria. La Plataforma no se responsabiliza por daños directos o indirectos derivados de usos indebidos, omisiones en la verificación de derechos o falta de consentimientos.
+
+## 9. Modificaciones y vigencia
+La Plataforma podrá actualizar estos Términos para reflejar cambios normativos, operativos o de seguridad. Se notificará a las personas usuarias mediante los canales habilitados. El uso continuado tras la actualización implica la aceptación de las nuevas condiciones.
+
+## 10. Contacto y asesoría legal
+Para consultas sobre estos Términos o solicitudes de autorización, escribir a legal@anclora.ai. Se recomienda revisar cada versión con asesoría legal calificada para garantizar su adecuación a los marcos regulatorios locales y sectoriales.
+
+Última actualización: {{FECHA_ACTUALIZACIÓN}}


### PR DESCRIPTION
## Summary
- add dedicated legal documentation covering terms of use, copyright and conversion guidelines
- document the privacy policy with consent management and rights verification procedures
- link the new legal resources from the README and the landing page content draft

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d02c0ed40883209a5538fc74f175e3