### PR TITLE
Add privacy management and right-to-forget workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 db
 __pycache__
 documents
+.pytest_cache
+.mypy_cache
+logs
 .venv
 tests.ipynb

--- a/app/agents/base.py
+++ b/app/agents/base.py
@@ -1,13 +1,71 @@
-"""Base utilities for file ingestion agents."""
+"""Shared building blocks for RAG agents and ingestors."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Tuple, Type
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Tuple, Type
 
 from common.text_normalization import Document
 
 
 LoaderConfig = Tuple[Type[object], Dict[str, object]]
+
+
+@dataclass(slots=True)
+class AgentResponse:
+    """Standard response format for agent interactions."""
+
+    success: bool
+    data: Dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class AgentTask:
+    """Encapsulates the payload that an agent receives."""
+
+    task_type: str
+    payload: Dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.task_type, str) or not self.task_type.strip():
+            raise ValueError("task_type must be a non-empty string")
+        self.task_type = self.task_type.strip()
+        if self.payload is None:
+            self.payload = {}
+        elif not isinstance(self.payload, dict):
+            self.payload = dict(self.payload)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Retrieve an item from the payload with ``default`` fallback."""
+
+        return self.payload.get(key, default) if self.payload is not None else default
+
+    def __getitem__(self, key: str) -> Any:
+        if self.payload is None:
+            raise KeyError(key)
+        return self.payload[key]
+
+
+class BaseAgent:
+    """Interface that all orchestrated agents must implement."""
+
+    name: str
+
+    def __init__(self, name: str) -> None:
+        if not name:
+            raise ValueError("Agent name must be provided")
+        self.name = name
+
+    def can_handle(self, task: AgentTask) -> bool:
+        """Return ``True`` if the agent can process *task*."""
+
+        raise NotImplementedError
+
+    def handle(self, task: AgentTask) -> AgentResponse:
+        """Process *task* and return a standardised response."""
+
+        raise NotImplementedError
 
 
 @dataclass
@@ -40,4 +98,11 @@ class BaseFileIngestor:
         return loader.load()
 
 
-__all__ = ["BaseFileIngestor", "LoaderConfig"]
+__all__ = [
+    "AgentResponse",
+    "AgentTask",
+    "BaseAgent",
+    "BaseFileIngestor",
+    "LoaderConfig",
+]
+

--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -6,13 +6,14 @@ import json
 import logging
 import os
 import secrets
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import Body, Depends, FastAPI, File, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, ConfigDict
 from common.langchain_module import response
+from common.privacy import PrivacyManager
 
 try:  # pragma: no cover - compatibilidad con httpx 0.28+
     import httpx
@@ -58,6 +59,7 @@ app = FastAPI(
 
 # Seguridad básica
 security = HTTPBearer()
+privacy_manager = PrivacyManager()
 
 # Modelos Pydantic
 class ChatRequest(BaseModel):
@@ -164,6 +166,53 @@ class ChatResponse(BaseModel):
                 },
             ]
         }
+
+
+class ForgetRequest(BaseModel):
+    filename: str = Field(
+        ...,
+        description="Nombre exacto del archivo que debe eliminarse de la base de conocimiento.",
+        example="informe_trimestral.pdf",
+    )
+    subject_id: Optional[str] = Field(
+        default=None,
+        description="Identificador del titular de los datos que solicita el borrado.",
+        example="cliente-123",
+    )
+    reason: Optional[str] = Field(
+        default=None,
+        description="Motivo o referencia interna asociada a la solicitud del derecho al olvido.",
+        example="Solicitud formal recibida el 2024-05-20",
+    )
+    metadata: Optional[dict[str, Any]] = Field(
+        default=None,
+        description="Metadatos adicionales que deban registrarse en la auditoría (se anonimizarán automáticamente).",
+        example={"canal": "portal_privacidad", "ticket": "GDPR-77"},
+    )
+
+
+class ForgetResponse(BaseModel):
+    status: str = Field(..., description="Resultado general de la operación.")
+    message: str = Field(..., description="Detalle resumido del resultado del proceso.")
+    audit_id: str = Field(..., description="Identificador único del registro de auditoría generado.")
+    removed_collections: List[str] = Field(
+        default_factory=list,
+        description="Colecciones de ChromaDB donde se localizaron y eliminaron referencias al archivo.",
+    )
+    removed_files: List[str] = Field(
+        default_factory=list,
+        description="Rutas de artefactos temporales eliminados durante la solicitud.",
+    )
+
+
+def _model_to_dict(model: BaseModel) -> dict[str, Any]:
+    """Compatibility helper to serialise Pydantic models across versions."""
+
+    dump_method = getattr(model, "model_dump", None)
+    if callable(dump_method):
+        return dump_method()
+    return model.dict()
+
 
 class FileInfo(BaseModel):
     filename: str = Field(
@@ -505,17 +554,81 @@ async def delete_document(
 ):
     """Elimina un documento indexado / Delete an indexed document."""
     try:
-        from common.ingest_file import delete_file_from_vectordb
-        delete_file_from_vectordb(filename)
-        
-        return {
-            "status": "success",
-            "message": f"Documento '{filename}' eliminado exitosamente"
-        }
-        
+        summary = privacy_manager.forget_document(
+            filename,
+            requested_by=token,
+            reason="delete_document_endpoint",
+        )
+
+        payload = ForgetResponse(
+            status="success" if summary.status == "deleted" else "not_found",
+            message=summary.message,
+            audit_id=summary.audit_id,
+            removed_collections=list(summary.removed_collections),
+            removed_files=[str(path) for path in summary.removed_files],
+        )
+
+        if summary.status != "deleted":
+            logger.warning("No se encontraron coincidencias para eliminar el documento %s", filename)
+
+        return _model_to_dict(payload)
+
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error al eliminar documento: {str(e)}")
         raise HTTPException(status_code=500, detail="Error al eliminar documento")
+
+
+@app.post(
+    "/privacy/forget",
+    response_model=ForgetResponse,
+    summary="Derecho al olvido / Right to be forgotten",
+    description=(
+        "Ejecuta el proceso completo de derecho al olvido, eliminando registros del RAG y "
+        "dejando constancia de la auditoría correspondiente.\n\n"
+        "Executes the full right-to-be-forgotten workflow, purging RAG data and registering the audit trail."
+    ),
+)
+async def execute_right_to_be_forgotten(
+    payload: ForgetRequest,
+    token: str = Depends(verify_token),
+):
+    """Procesa una solicitud formal del derecho al olvido / Process a right-to-be-forgotten request."""
+
+    try:
+        summary = privacy_manager.forget_document(
+            payload.filename,
+            requested_by=token,
+            subject_id=payload.subject_id,
+            reason=payload.reason,
+            extra_metadata=payload.metadata or {},
+        )
+
+        response = ForgetResponse(
+            status="success" if summary.status == "deleted" else "not_found",
+            message=summary.message,
+            audit_id=summary.audit_id,
+            removed_collections=list(summary.removed_collections),
+            removed_files=[str(path) for path in summary.removed_files],
+        )
+
+        if summary.status != "deleted":
+            logger.info(
+                "Solicitud de olvido procesada sin coincidencias para el archivo %s",
+                payload.filename,
+            )
+
+        return _model_to_dict(response)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Error al ejecutar el derecho al olvido: %s", exc)
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible completar la solicitud de olvido",
+        )
 
 # Middleware para CORS (si es necesario)
 from fastapi.middleware.cors import CORSMiddleware

--- a/app/common/privacy.py
+++ b/app/common/privacy.py
@@ -1,0 +1,330 @@
+"""Utilities to enforce privacy requests and anonymize stored metadata."""
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from .constants import CHROMA_COLLECTIONS, CHROMA_SETTINGS
+
+logger = logging.getLogger(__name__)
+
+
+ANONYMIZED_VALUE = "***REDACTED***"
+_SENSITIVE_KEYWORDS = (
+    "name",
+    "email",
+    "phone",
+    "user",
+    "customer",
+    "document",
+    "identifier",
+    "dni",
+    "ssn",
+)
+
+
+@dataclass(slots=True)
+class PrivacyAuditRecord:
+    """Structured payload describing a privacy related action."""
+
+    audit_id: str
+    filename: str
+    requested_by: str
+    status: str
+    message: str
+    collections: Sequence[str]
+    removed_files: Sequence[Path]
+    subject_id: str | None = None
+    reason: str | None = None
+    metadata: Mapping[str, Any] | None = None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass(slots=True)
+class PrivacyActionSummary:
+    """Result of executing the right-to-be-forgotten workflow."""
+
+    filename: str
+    status: str
+    message: str
+    audit_id: str
+    removed_collections: Sequence[str]
+    removed_files: Sequence[Path]
+    metadata: Mapping[str, Any]
+
+
+class PrivacyAuditLogger:
+    """Persistent logger that stores structured privacy audit records."""
+
+    def __init__(self, log_path: str | Path | None = None) -> None:
+        self.log_path = Path(log_path) if log_path is not None else Path("logs") / "privacy_audit.log"
+        logger_name = f"privacy_audit.{self.log_path.resolve()}"
+        self._logger = logging.getLogger(logger_name)
+        if not self._logger.handlers:
+            self.log_path.parent.mkdir(parents=True, exist_ok=True)
+            handler = logging.FileHandler(self.log_path, encoding="utf-8")
+            handler.setFormatter(logging.Formatter("%(message)s"))
+            self._logger.addHandler(handler)
+        self._logger.setLevel(logging.INFO)
+        self._logger.propagate = False
+
+    def log(self, record: PrivacyAuditRecord) -> None:
+        payload = {
+            "audit_id": record.audit_id,
+            "timestamp": record.timestamp.isoformat(),
+            "filename": record.filename,
+            "requested_by": record.requested_by,
+            "status": record.status,
+            "message": record.message,
+            "subject_id": record.subject_id,
+            "reason": record.reason,
+            "collections": list(record.collections),
+            "removed_files": [str(path) for path in record.removed_files],
+            "metadata": record.metadata or {},
+        }
+        self._logger.info(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+
+
+class PrivacyManager:
+    """Centralizes privacy preserving utilities for the RAG platform."""
+
+    def __init__(
+        self,
+        *,
+        chroma_client: Any | None = None,
+        collections: Mapping[str, Any] | None = None,
+        storage_locations: Sequence[str | Path] | None = None,
+        temporary_locations: Sequence[str | Path] | None = None,
+        audit_logger: PrivacyAuditLogger | None = None,
+    ) -> None:
+        self._chroma_client = chroma_client or CHROMA_SETTINGS
+        self._collections = collections or CHROMA_COLLECTIONS
+        storage_roots = [Path(location) for location in (storage_locations or (Path("documents"),))]
+        temp_roots = [Path(location) for location in (temporary_locations or (Path(tempfile.gettempdir()), Path("documents")))]
+        self._storage_locations = tuple(storage_roots)
+        self._temporary_locations = tuple(temp_roots)
+        self._audit_logger = audit_logger or PrivacyAuditLogger()
+
+    # ---------------------------------------------------------------------
+    # Metadata handling helpers
+    def anonymize_metadata(self, metadata: Mapping[str, Any]) -> dict[str, Any]:
+        """Return a sanitized copy of ``metadata`` with sensitive values redacted."""
+
+        def _sanitize(key: str, value: Any) -> Any:
+            if isinstance(value, Mapping):
+                return {inner_key: _sanitize(inner_key, inner_value) for inner_key, inner_value in value.items()}
+            if isinstance(value, list):
+                return [_sanitize(key, item) for item in value]
+            if isinstance(value, str) and self._is_sensitive_field(key, value):
+                return self._mask_value(value)
+            return value
+
+        return {key: _sanitize(key, value) for key, value in metadata.items()}
+
+    def _is_sensitive_field(self, key: str, value: str) -> bool:
+        lowered = key.lower()
+        if any(keyword in lowered for keyword in _SENSITIVE_KEYWORDS):
+            return True
+        if "@" in value:
+            return True
+        if value.strip().isdigit() and len(value.strip()) >= 6:
+            return True
+        return False
+
+    @staticmethod
+    def _mask_value(value: str) -> str:
+        return ANONYMIZED_VALUE
+
+    # ------------------------------------------------------------------
+    # Deletion helpers
+    def forget_document(
+        self,
+        filename: str,
+        *,
+        requested_by: str,
+        subject_id: str | None = None,
+        reason: str | None = None,
+        extra_metadata: Mapping[str, Any] | None = None,
+    ) -> PrivacyActionSummary:
+        """Remove document traces from vector stores and temporary storage."""
+
+        if not filename or not filename.strip():
+            raise ValueError("filename must be a non-empty string")
+
+        filename = filename.strip()
+        audit_id = uuid.uuid4().hex
+
+        deleted_collections = self._delete_from_collections(filename)
+        removed_files = self._remove_local_artifacts(filename)
+
+        status = "deleted" if deleted_collections or removed_files else "not_found"
+        message = (
+            "Documento eliminado de la base de conocimiento y del almacenamiento temporal / "
+            "Document removed from the knowledge base and temporary storage"
+            if status == "deleted"
+            else "No se encontraron coincidencias para el documento solicitado / "
+            "No entries matching the document were found"
+        )
+
+        metadata = self.anonymize_metadata(extra_metadata or {})
+
+        record = PrivacyAuditRecord(
+            audit_id=audit_id,
+            filename=filename,
+            requested_by=requested_by,
+            status=status,
+            message=message,
+            subject_id=subject_id,
+            reason=reason,
+            collections=deleted_collections,
+            removed_files=removed_files,
+            metadata=metadata,
+        )
+
+        try:
+            self._audit_logger.log(record)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("No fue posible registrar la auditoría de privacidad: %s", exc)
+
+        return PrivacyActionSummary(
+            filename=filename,
+            status=status,
+            message=message,
+            audit_id=audit_id,
+            removed_collections=deleted_collections,
+            removed_files=removed_files,
+            metadata=metadata,
+        )
+
+    # Internal helpers -------------------------------------------------
+    def _delete_from_collections(self, filename: str) -> list[str]:
+        affected: list[str] = []
+        for collection_name in self._collections:
+            try:
+                collection = self._chroma_client.get_or_create_collection(collection_name)
+            except Exception as exc:  # pragma: no cover - defensive fallback
+                logger.error("No se pudo obtener la colección %s: %s", collection_name, exc)
+                continue
+
+            ids_to_delete = self._find_matching_ids(collection, filename)
+            if not ids_to_delete:
+                continue
+
+            try:
+                collection.delete(ids=list(ids_to_delete))
+            except Exception as exc:  # pragma: no cover - delete may fail
+                logger.error("No se pudo eliminar %s de la colección %s: %s", filename, collection_name, exc)
+                continue
+
+            affected.append(collection_name)
+
+        return affected
+
+    def _find_matching_ids(self, collection: Any, filename: str) -> list[str]:
+        """Return ids within *collection* that reference *filename*."""
+
+        queries = (
+            {"uploaded_file_name": filename},
+            {"source": filename},
+        )
+        for query in queries:
+            try:
+                response = collection.get(where=query, include=["ids", "metadatas"])
+            except Exception:
+                continue
+            ids = self._extract_matching_ids(response, filename)
+            if ids:
+                return ids
+
+        try:
+            response = collection.get(include=["ids", "metadatas"])
+        except Exception:  # pragma: no cover - compatibility fallback
+            return []
+        return self._extract_matching_ids(response, filename)
+
+    @staticmethod
+    def _extract_matching_ids(response: Any, filename: str) -> list[str]:
+        if not isinstance(response, Mapping):
+            return []
+
+        raw_ids = response.get("ids") or []
+        metadatas = response.get("metadatas") or []
+
+        matched: list[str] = []
+        for doc_id, metadata in zip(raw_ids, metadatas):
+            if not isinstance(doc_id, str) or not isinstance(metadata, Mapping):
+                continue
+            uploaded_name = metadata.get("uploaded_file_name")
+            source = metadata.get("source")
+            if uploaded_name == filename:
+                matched.append(doc_id)
+                continue
+            if isinstance(source, str) and source.endswith(filename):
+                matched.append(doc_id)
+
+        return matched
+
+    def _remove_local_artifacts(self, filename: str) -> list[Path]:
+        removed: list[Path] = []
+        for location in self._storage_locations:
+            removed.extend(self._unlink_matches(location, filename, recursive=True))
+        for location in self._temporary_locations:
+            removed.extend(self._unlink_matches(location, filename, recursive=False, allow_suffix=True))
+
+        # Remove duplicates while preserving order
+        seen: set[Path] = set()
+        unique_removed: list[Path] = []
+        for path in removed:
+            if path in seen:
+                continue
+            seen.add(path)
+            unique_removed.append(path)
+        return unique_removed
+
+    def _unlink_matches(
+        self,
+        base_path: Path,
+        filename: str,
+        *,
+        recursive: bool,
+        allow_suffix: bool = False,
+    ) -> list[Path]:
+        if not base_path.exists() or not base_path.is_dir():
+            return []
+
+        patterns: Iterable[str]
+        if allow_suffix:
+            patterns = (filename, f"*{filename}")
+        else:
+            patterns = (filename,)
+
+        matches: list[Path] = []
+        iterator = base_path.rglob if recursive else base_path.glob
+        for pattern in patterns:
+            try:
+                for candidate in iterator(pattern):
+                    if not candidate.is_file():
+                        continue
+                    try:
+                        candidate.unlink()
+                        matches.append(candidate)
+                    except FileNotFoundError:
+                        continue
+            except Exception:  # pragma: no cover - e.g. permission issues
+                continue
+        return matches
+
+
+__all__ = [
+    "ANONYMIZED_VALUE",
+    "PrivacyActionSummary",
+    "PrivacyAuditLogger",
+    "PrivacyManager",
+]
+

--- a/docs/compliance/gdpr_ccpa.md
+++ b/docs/compliance/gdpr_ccpa.md
@@ -1,0 +1,88 @@
+# Cumplimiento GDPR y CCPA
+
+Este documento describe cómo Anclora AI RAG implementa controles de privacidad
+para cumplir con los principios de **minimización**, **limitación de
+propósitos** y **derechos de los titulares de los datos** establecidos en GDPR y
+CCPA. Las prácticas aquí documentadas son de obligatorio cumplimiento para el
+equipo de operaciones y para cualquier socio tecnológico que interactúe con el
+sistema.
+
+## Roles y responsabilidades
+
+| Rol | Responsable | Funciones clave |
+| --- | ----------- | --------------- |
+| Responsable de Privacidad | Oficial de Protección de Datos (DPO) | Validar políticas, aprobar solicitudes de sujetos y coordinar auditorías externas. |
+| Líder Técnico de RAG | Arquitecto de Plataforma | Mantener los módulos de ingestión y borrado, validar registros de auditoría y publicar actualizaciones técnicas. |
+| Operaciones / Soporte | Equipo de Operaciones 24/7 | Recibir solicitudes, ejecutar el flujo de derecho al olvido y documentar incidentes. |
+| Seguridad de la Información | CISO | Revisar controles de acceso, monitorear anomalías y garantizar el resguardo de logs. |
+
+## Flujo del derecho al olvido
+
+1. **Recepción**: la solicitud llega por el portal de privacidad, correo o
+   canal interno. El Operador genera un ticket (ej. `GDPR-001`).
+2. **Validación**: el DPO confirma la identidad del solicitante y verifica que
+   la información esté dentro del alcance de Anclora AI RAG.
+3. **Ejecución**:
+   - Se invoca el endpoint `POST /privacy/forget` o el comando interno con el
+     identificador del archivo y el `subject_id` asociado.
+   - El módulo `PrivacyManager` elimina referencias en ChromaDB, purga archivos
+     temporales (incluyendo staging `documents/` y `tempfile.gettempdir()`),
+     anonimiza metadatos y escribe un registro de auditoría en
+     `logs/privacy_audit.log`.
+4. **Verificación**:
+   - El Operador revisa el log para confirmar el `audit_id` generado y valida
+     que las colecciones y archivos eliminados coinciden con el alcance de la
+     solicitud.
+   - Se ejecutan pruebas automatizadas (`pytest tests/test_privacy.py`) cuando
+     haya cambios en los pipelines de ingestión o privacidad.
+5. **Confirmación**: se notifica al solicitante compartiendo el identificador
+   de auditoría y la fecha de cumplimiento.
+
+## Checklists operativos
+
+### Antes de cargar datos (responsable: Líder Técnico de RAG)
+
+- [ ] Revisar contratos de tratamiento y bases legales para nuevos datasets.
+- [ ] Garantizar que los archivos fuente estén rotulados con el dominio correcto
+      (`documents`, `code`, `multimedia`).
+- [ ] Validar que los metadatos sensibles estén anonimizados o pseudonimizados
+      antes de la ingesta.
+
+### Al recibir una solicitud de derecho al olvido (responsable: Operaciones)
+
+- [ ] Confirmar identidad del solicitante junto con el DPO.
+- [ ] Registrar ticket con canal, fecha y `subject_id`.
+- [ ] Ejecutar `POST /privacy/forget` con el `filename` exacto y metadatos
+      asociados.
+- [ ] Verificar el `audit_id` y adjuntarlo al ticket.
+- [ ] Cerrar la solicitud con evidencia (capturas de log y respuesta del
+      endpoint).
+
+### Auditoría mensual (responsable: Seguridad de la Información)
+
+- [ ] Revisar `logs/privacy_audit.log` en busca de anomalías o accesos fuera de
+      horario.
+- [ ] Validar integridad y retención de logs (mínimo 12 meses).
+- [ ] Confirmar que las pruebas automáticas de privacidad se ejecutaron en el
+      pipeline de CI.
+- [ ] Informar hallazgos al DPO y definir acciones correctivas.
+
+## Matriz de comunicación
+
+- **Incidente o brecha**: notificar de inmediato al CISO y al DPO. Activar el
+  plan de respuesta y registrar los eventos en menos de 24 horas.
+- **Consultas de usuarios finales**: canalizar vía Operaciones. Responder en un
+  máximo de 72 horas con el estado del caso.
+- **Cambios en la normativa**: el DPO actualiza este documento y convoca a
+  capacitación obligatoria al resto de los roles.
+
+## Evidencia y trazabilidad
+
+- Todos los registros generados por `PrivacyManager` deben almacenarse con
+  control de acceso de solo lectura para Operaciones y lectura/escritura para el
+  DPO.
+- El repositorio debe incluir pruebas unitarias que verifiquen la eliminación de
+  datos (ver `tests/test_privacy.py`).
+- El equipo técnico debe conservar evidencia de las ejecuciones exitosas de
+  `pytest` y de los despliegues que afecten el pipeline de datos.
+

--- a/tests/test_privacy.py
+++ b/tests/test_privacy.py
@@ -1,0 +1,129 @@
+"""Tests for the privacy utilities in ``app.common.privacy``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Mapping
+
+from app.common.privacy import (
+    ANONYMIZED_VALUE,
+    PrivacyAuditLogger,
+    PrivacyManager,
+)
+
+
+class _StubCollection:
+    def __init__(self, documents: Mapping[str, Dict[str, object]]) -> None:
+        self._documents = dict(documents)
+        self.deleted_ids: list[list[str]] = []
+
+    def get(self, where: Mapping[str, object] | None = None, include: list[str] | None = None):
+        ids: list[str] = []
+        metadatas: list[Dict[str, object]] = []
+        for doc_id, metadata in self._documents.items():
+            if self._matches(metadata, where):
+                ids.append(doc_id)
+                metadatas.append(dict(metadata))
+        return {"ids": ids, "metadatas": metadatas}
+
+    def delete(self, ids: list[str] | None = None) -> None:
+        if not ids:
+            return
+        self.deleted_ids.append(list(ids))
+        for doc_id in ids:
+            self._documents.pop(doc_id, None)
+
+    @staticmethod
+    def _matches(metadata: Mapping[str, object], where: Mapping[str, object] | None) -> bool:
+        if not where:
+            return True
+        for key, value in where.items():
+            candidate = metadata.get(key)
+            if key == "source" and isinstance(candidate, str) and isinstance(value, str):
+                if candidate.endswith(value):
+                    continue
+            if candidate != value:
+                return False
+        return True
+
+
+class _StubChromaClient:
+    def __init__(self, collections: Mapping[str, _StubCollection]) -> None:
+        self._collections = collections
+
+    def get_or_create_collection(self, name: str) -> _StubCollection:
+        return self._collections[name]
+
+
+def test_privacy_manager_deletes_collections_and_storage(tmp_path: Path) -> None:
+    """The manager should remove vector entries and temporary files."""
+
+    storage_dir = tmp_path / "documents"
+    storage_dir.mkdir()
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
+
+    filename = "datos_cliente.pdf"
+    (storage_dir / filename).write_text("contenido")
+    (temp_dir / f"123_{filename}").write_text("temporal")
+
+    collection = _StubCollection(
+        {
+            "id-1": {"uploaded_file_name": filename},
+            "id-2": {"uploaded_file_name": "otro.pdf"},
+        }
+    )
+    collections = {"conversion_rules": collection}
+    chroma = _StubChromaClient(collections)
+
+    audit_log = tmp_path / "audit.log"
+
+    manager = PrivacyManager(
+        chroma_client=chroma,
+        collections=collections,
+        storage_locations=[storage_dir],
+        temporary_locations=[temp_dir],
+        audit_logger=PrivacyAuditLogger(log_path=audit_log),
+    )
+
+    summary = manager.forget_document(
+        filename,
+        requested_by="tester",
+        subject_id="user-42",
+        reason="GDPR",
+        extra_metadata={"email": "person@example.com", "notes": "Eliminar"},
+    )
+
+    assert summary.status == "deleted"
+    assert "conversion_rules" in summary.removed_collections
+    assert {path.name for path in summary.removed_files} == {filename, f"123_{filename}"}
+    assert not (storage_dir / filename).exists()
+    assert not any(temp_dir.iterdir())
+    assert collection.deleted_ids and collection.deleted_ids[-1] == ["id-1"]
+    assert summary.metadata["email"] == ANONYMIZED_VALUE
+
+    log_payload = json.loads(audit_log.read_text(encoding="utf-8").splitlines()[-1])
+    assert log_payload["audit_id"] == summary.audit_id
+    assert log_payload["metadata"]["email"] == ANONYMIZED_VALUE
+    assert "person@example.com" not in audit_log.read_text(encoding="utf-8")
+
+
+def test_privacy_manager_reports_missing_documents(tmp_path: Path) -> None:
+    """The manager should return ``not_found`` when nothing matches."""
+
+    collections = {"conversion_rules": _StubCollection({})}
+    chroma = _StubChromaClient(collections)
+    manager = PrivacyManager(
+        chroma_client=chroma,
+        collections=collections,
+        storage_locations=[tmp_path / "docs"],
+        temporary_locations=[tmp_path / "tmp"],
+        audit_logger=PrivacyAuditLogger(log_path=tmp_path / "audit.log"),
+    )
+
+    summary = manager.forget_document("no_existe.txt", requested_by="tester")
+
+    assert summary.status == "not_found"
+    assert not summary.removed_collections
+    assert not summary.removed_files


### PR DESCRIPTION
## Summary
- add a reusable privacy manager that anonymizes metadata, deletes vector records and removes temporary artefacts while writing structured audits
- expose right-to-be-forgotten support via new FastAPI models/endpoints and reuse the privacy manager in existing delete flows
- refactor ingestion utilities to work with a ProcessedFile container and document GDPR/CCPA responsibilities alongside new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02c0329b88320bafbf65a5d43ae2b