### PR TITLE
Parametriza cliente de Chroma y documenta variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ build --no-cache` para los servicios `ui` y `api`.
 - Volumen persistente para ChromaDB
 - Variables de entorno para selección de modelo y configuración de embeddings
 
+#### Variables de entorno para ChromaDB
+
+Los servicios `ui` y `api` consumen ChromaDB mediante las variables de entorno `CHROMA_HOST` y `CHROMA_PORT`, definidas en los archivos `docker-compose*.yml` con los valores por defecto `chroma` y `8000`. Estos valores permiten que ambos servicios descubran automáticamente al contenedor `chroma` cuando el stack se ejecuta con Docker Compose.
+
+Si ejecutas la aplicación fuera de Docker (por ejemplo, para desarrollo local), establece las variables antes de iniciar Streamlit o la API para apuntar al host correspondiente:
+
+```bash
+export CHROMA_HOST=localhost
+export CHROMA_PORT=8000
+streamlit run app/Inicio.py
+# o
+uvicorn app.api_endpoints:app --reload --port 8081
+```
+
+También puedes ajustar `CHROMA_HOST` y `CHROMA_PORT` a los valores de cualquier instancia remota de ChromaDB que quieras reutilizar.
+
 ### Archivos Principales
 
 **Punto de Entrada**: app/Inicio.py

--- a/app/common/constants.py
+++ b/app/common/constants.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Mapping
 
@@ -9,6 +10,50 @@ import chromadb
 from chromadb.config import Settings
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_CHROMA_HOST = "chroma"
+_DEFAULT_CHROMA_PORT = 8000
+
+
+def _get_chroma_host() -> str:
+    """Return the configured Chroma host or the default value."""
+
+    host = os.getenv("CHROMA_HOST", _DEFAULT_CHROMA_HOST).strip()
+    if not host:
+        logger.warning(
+            "Se recibió un valor vacío para CHROMA_HOST. Se utilizará el valor por defecto '%s'.",
+            _DEFAULT_CHROMA_HOST,
+        )
+        return _DEFAULT_CHROMA_HOST
+    return host
+
+
+def _get_chroma_port() -> int:
+    """Return the configured Chroma port as an integer, with fallbacks."""
+
+    raw_port = os.getenv("CHROMA_PORT")
+    if raw_port is None:
+        return _DEFAULT_CHROMA_PORT
+
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError):  # pragma: no cover - defensive path
+        logger.warning(
+            "No fue posible interpretar el valor '%s' de CHROMA_PORT. Se utilizará el valor por defecto %s.",
+            raw_port,
+            _DEFAULT_CHROMA_PORT,
+        )
+        return _DEFAULT_CHROMA_PORT
+
+    if port <= 0:  # pragma: no cover - defensive path
+        logger.warning(
+            "El valor de CHROMA_PORT debe ser positivo. Se recibió '%s'. Se utilizará el valor por defecto %s.",
+            raw_port,
+            _DEFAULT_CHROMA_PORT,
+        )
+        return _DEFAULT_CHROMA_PORT
+
+    return port
 
 
 @dataclass(frozen=True)
@@ -51,17 +96,21 @@ DOMAIN_TO_COLLECTION: Mapping[str, str] = {
 def _create_chroma_client() -> chromadb.api.ClientAPI:
     """Create a ChromaDB client, falling back to an in-memory instance if remote access fails."""
 
+    host = _get_chroma_host()
+    port = _get_chroma_port()
     settings = Settings(allow_reset=True, anonymized_telemetry=False)
 
     try:
         return chromadb.HttpClient(
-            host="host.docker.internal",
-            port=8000,
+            host=host,
+            port=port,
             settings=settings,
         )
     except Exception as exc:  # pragma: no cover - defensive path
         logger.warning(
-            "No fue posible conectar con el servicio remoto de ChromaDB (%s). Se usará un cliente en memoria.",
+            "No fue posible conectar con el servicio remoto de ChromaDB en %s:%s (%s). Se usará un cliente en memoria.",
+            host,
+            port,
             exc,
         )
         local_settings = Settings(

--- a/app/pages/Archivos.py
+++ b/app/pages/Archivos.py
@@ -7,15 +7,6 @@ except ImportError:
     import sys
     sys.exit(1)
 
-# Try to import the required modules, and if they fail, provide helpful error messages
-try:
-    import chromadb  # type: ignore
-    from chromadb.config import Settings  # type: ignore
-except ImportError:
-    print("Error: chromadb module not found. Please install it with 'pip install chromadb==0.4.7'")
-    import sys
-    sys.exit(1)
-
 try:
     from langchain_community.embeddings import HuggingFaceEmbeddings  # type: ignore
 except ImportError:
@@ -33,6 +24,7 @@ try:
         delete_file_from_vectordb,
         ingest_file,
     )
+    from common.constants import CHROMA_SETTINGS
     from common.streamlit_style import hide_streamlit_style
     from common.translations import get_text
 except ImportError:
@@ -87,7 +79,6 @@ with st.sidebar:
         st.session_state.language = selected_language
         st.rerun()
 # Define the Chroma settings
-CHROMA_SETTINGS = chromadb.HttpClient(host="host.docker.internal", port = 8000, settings=Settings(allow_reset=True, anonymized_telemetry=False))
 collection = CHROMA_SETTINGS.get_or_create_collection(name='vectordb')
 embeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
         # Embedding model used for document ingestion and retrieval
         - EMBEDDINGS_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
         - TARGET_SOURCE_CHUNKS=5
+        - CHROMA_HOST=${CHROMA_HOST:-chroma}
+        - CHROMA_PORT=${CHROMA_PORT:-8000}
         - ANCLORA_API_TOKENS=${ANCLORA_API_TOKENS:-}
         - ANCLORA_API_TOKEN=${ANCLORA_API_TOKEN:-}
         - ANCLORA_JWT_SECRET=${ANCLORA_JWT_SECRET:-}
@@ -85,6 +87,8 @@ services:
         # Embedding model used for document ingestion and retrieval
         - EMBEDDINGS_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
         - TARGET_SOURCE_CHUNKS=5
+        - CHROMA_HOST=${CHROMA_HOST:-chroma}
+        - CHROMA_PORT=${CHROMA_PORT:-8000}
         - PROMETHEUS_METRICS_PORT=9001
         - PROMETHEUS_METRICS_HOST=0.0.0.0
       command: ["python", "-m", "uvicorn", "api_endpoints:app", "--host", "0.0.0.0", "--port", "8081"]

--- a/docker-compose_sin_gpu.yml
+++ b/docker-compose_sin_gpu.yml
@@ -34,6 +34,8 @@ services:
         # Embedding model used for document ingestion and retrieval
         - EMBEDDINGS_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
         - TARGET_SOURCE_CHUNKS=5
+        - CHROMA_HOST=${CHROMA_HOST:-chroma}
+        - CHROMA_PORT=${CHROMA_PORT:-8000}
         - PROMETHEUS_METRICS_PORT=9000
         - PROMETHEUS_METRICS_HOST=0.0.0.0
       healthcheck:
@@ -60,6 +62,8 @@ services:
         # Embedding model used for document ingestion and retrieval
         - EMBEDDINGS_MODEL_NAME=sentence-transformers/all-mpnet-base-v2
         - TARGET_SOURCE_CHUNKS=5
+        - CHROMA_HOST=${CHROMA_HOST:-chroma}
+        - CHROMA_PORT=${CHROMA_PORT:-8000}
         - ANCLORA_API_TOKENS=${ANCLORA_API_TOKENS:-}
         - ANCLORA_API_TOKEN=${ANCLORA_API_TOKEN:-}
         - ANCLORA_JWT_SECRET=${ANCLORA_JWT_SECRET:-}


### PR DESCRIPTION
## Summary
- centralize the Chroma client factory to read CHROMA_HOST and CHROMA_PORT with sensible defaults
- reuse the shared client from the archivos page and expose the variables in both docker-compose variants
- document how to override the Chroma connection when running the app outside Docker

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d099cb0bc8832096efe68fb6b7a587