### PR TITLE
Allow startup scripts to fall back to default API token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Copia este archivo a .env y reemplaza los valores según tus credenciales reales.
+# El token por defecto permite levantar la pila en entornos locales sin configurar
+# credenciales personalizadas. Producción debe sobrescribirlo con valores seguros.
+ANCLORA_DEFAULT_API_TOKEN=your-api-key-here
+
+# Define uno o varios tokens separados por comas para la API si quieres deshabilitar
+# el token por defecto.
+# ANCLORA_API_TOKENS=token-1,token-2
+
+# También puedes usar JWT firmados. Si defines ANCLORA_JWT_SECRET se ignorará el token por defecto.
+# ANCLORA_JWT_SECRET=cambia-esta-clave
+# ANCLORA_JWT_ALGORITHMS=HS256
+# ANCLORA_JWT_ISSUER=
+# ANCLORA_JWT_AUDIENCE=

--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ El detalle de fases, épicas y tareas priorizadas se encuentra en el [backlog de
 
 - [Guía de Integración / Integration Guide](docs/integration-guide.md): Pasos para consumir la API, usar el cliente Python oficial y conectar agentes (LangChain, AutoGen) con recomendaciones de encoding y manejo de Unicode.
 
+### Configuración de credenciales
+
+Los scripts `open_rag.sh` (Linux/macOS) y `open_rag.bat` (Windows) cargan automáticamente el archivo `.env` si existe. Si no defines `ANCLORA_API_TOKENS` ni `ANCLORA_JWT_SECRET`, se reutilizará el valor de `ANCLORA_DEFAULT_API_TOKEN` y se mostrará una advertencia indicando que se usará el token por defecto. Esto permite levantar la pila rápidamente en entornos locales manteniendo la opción de reforzar la seguridad en producción.
+
+Para inyectar credenciales reales, copia el archivo `.env.example` a `.env` y reemplaza los valores por los de tu entorno:
+
+```bash
+cp .env.example .env
+# Edita .env y define ANCLORA_API_TOKENS o ANCLORA_JWT_SECRET con tus credenciales.
+```
+
+En producción se recomienda definir tus propios tokens o secretos JWT para deshabilitar el token de ejemplo.
+
 ### Información legal y cumplimiento
 
 - [Términos y Condiciones de Uso](docs/legal/terms.md): reglas de uso de la plataforma, política de consentimiento y proceso de verificación de derechos antes de cada conversión.

--- a/open_rag.bat
+++ b/open_rag.bat
@@ -15,8 +15,14 @@ if exist .env (
 )
 
 if not defined ANCLORA_API_TOKENS if not defined ANCLORA_JWT_SECRET (
-  echo [ERROR] Debes definir ANCLORA_API_TOKENS o ANCLORA_JWT_SECRET antes de iniciar los servicios.
-  exit /b 1
+  if defined ANCLORA_DEFAULT_API_TOKEN (
+    set "ANCLORA_API_TOKENS=%ANCLORA_DEFAULT_API_TOKEN%"
+    set "ANCLORA_API_TOKEN=%ANCLORA_DEFAULT_API_TOKEN%"
+    >&2 echo [WARN] No se definieron ANCLORA_API_TOKENS ni ANCLORA_JWT_SECRET; se usará el token por defecto.
+  ) else (
+    >&2 echo [ERROR] Debes definir ANCLORA_API_TOKENS, ANCLORA_JWT_SECRET o ANCLORA_DEFAULT_API_TOKEN antes de iniciar los servicios.
+    exit /b 1
+  )
 )
 
 docker-compose up -d %*

--- a/open_rag.sh
+++ b/open_rag.sh
@@ -12,8 +12,14 @@ if [[ -f .env ]]; then
 fi
 
 if [[ -z "${ANCLORA_API_TOKENS:-}" && -z "${ANCLORA_JWT_SECRET:-}" ]]; then
-  echo "[ERROR] Debes definir ANCLORA_API_TOKENS o ANCLORA_JWT_SECRET antes de iniciar los servicios." >&2
-  exit 1
+  if [[ -n "${ANCLORA_DEFAULT_API_TOKEN:-}" ]]; then
+    export ANCLORA_API_TOKENS="${ANCLORA_DEFAULT_API_TOKEN}"
+    export ANCLORA_API_TOKEN="${ANCLORA_DEFAULT_API_TOKEN}"
+    echo "[WARN] No se definieron ANCLORA_API_TOKENS ni ANCLORA_JWT_SECRET; se usará el token por defecto." >&2
+  else
+    echo "[ERROR] Debes definir ANCLORA_API_TOKENS, ANCLORA_JWT_SECRET o ANCLORA_DEFAULT_API_TOKEN antes de iniciar los servicios." >&2
+    exit 1
+  fi
 fi
 
 docker-compose up -d "$@"


### PR DESCRIPTION
## Summary
- make the startup scripts reuse ANCLORA_DEFAULT_API_TOKEN when no custom credentials are configured and emit a warning
- document the credential bootstrap process in the README and add a .env example for overriding tokens

## Testing
- PATH="$tmpdir:$PATH" ANCLORA_DEFAULT_API_TOKEN=token-def ./open_rag.sh --no-start
- PATH="$tmpdir:$PATH" ANCLORA_API_TOKENS=mi-token ./open_rag.sh --no-start

------
https://chatgpt.com/codex/tasks/task_e_68d099d388408320ae5ec0f5fbb90da2