### PR TITLE
Limit greeting responses to very short queries

### DIFF
--- a/app/common/langchain_module.py
+++ b/app/common/langchain_module.py
@@ -187,7 +187,9 @@ def response(query: str, language: Optional[str] = None) -> str:
         }
         normalized_query_lower = stripped_query.lower()
 
-        if any(greeting in normalized_query_lower for greeting in simple_greetings[language_code]) and len(stripped_query.split()) <= 4:
+        word_count = len(re.findall(r"\w+", stripped_query))
+
+        if any(greeting in normalized_query_lower for greeting in simple_greetings[language_code]) and word_count <= 4:
             greeting_text = _translate("greeting_response", language_code)
 
             if os.getenv("PYTEST_CURRENT_TEST"):

--- a/tests/test_langchain_module.py
+++ b/tests/test_langchain_module.py
@@ -1,5 +1,7 @@
 """Tests for helpers in ``app.common.langchain_module``."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from app.common.langchain_module import detect_language, response
@@ -44,3 +46,129 @@ def test_response_uses_detected_language_when_not_provided(
     result = response(query, language=provided_language)
 
     assert result == f"greeting_response:{expected_language}"
+
+
+def test_response_long_greeting_invokes_rag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Consultas largas deben evitar la rama de saludos y ejecutar el flujo de RAG."""
+
+    query = "Hola necesito el informe trimestral"
+
+    def fake_get_text(key: str, language: str, **_: object) -> str:
+        return f"{key}:{language}"
+
+    monkeypatch.setattr("app.common.langchain_module.get_text", fake_get_text)
+    monkeypatch.setattr(
+        "app.common.langchain_module.parse_arguments",
+        lambda: SimpleNamespace(hide_source=False, mute_stream=True),
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.HuggingFaceEmbeddings",
+        lambda model_name: SimpleNamespace(model_name=model_name),
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.record_rag_response",
+        lambda *args, **kwargs: None,
+    )
+
+    class FakeCollection:
+        def count(self) -> int:
+            return 2
+
+    fake_client = SimpleNamespace(
+        get_collection=lambda name: FakeCollection(),
+    )
+    monkeypatch.setattr("app.common.langchain_module.CHROMA_SETTINGS", fake_client)
+
+    class FakeRunnable:
+        def __init__(self, func):
+            self._func = func
+
+        def invoke(self, value):
+            return self._func(value)
+
+        def __call__(self, value):
+            return self._func(value)
+
+        def __or__(self, other):
+            if isinstance(other, FakeRunnable):
+                return FakeRunnable(lambda value: other.invoke(self.invoke(value)))
+            if callable(other):
+                return FakeRunnable(lambda value: other(self.invoke(value)))
+            return NotImplemented
+
+        def __ror__(self, other):
+            if isinstance(other, FakeRunnable):
+                return FakeRunnable(lambda value: self.invoke(other.invoke(value)))
+            if callable(other):
+                return FakeRunnable(lambda value: self.invoke(other(value)))
+            return NotImplemented
+
+    class FakeRetriever:
+        def __init__(self) -> None:
+            self.queries: list[str] = []
+
+        def __call__(self, rag_query: str):
+            self.queries.append(rag_query)
+            return [SimpleNamespace(page_content="Contexto simulado")]
+
+        def __or__(self, formatter):
+            return FakeRunnable(lambda rag_query: formatter(self(rag_query)))
+
+    fake_retriever = FakeRetriever()
+
+    class FakeChroma:
+        def __init__(self, *_, **__):
+            pass
+
+        def as_retriever(self, **_):
+            return fake_retriever
+
+    monkeypatch.setattr("app.common.langchain_module.Chroma", FakeChroma)
+
+    monkeypatch.setattr(
+        "app.common.langchain_module.RunnablePassthrough",
+        lambda: FakeRunnable(lambda value: value),
+    )
+
+    class FakePrompt:
+        def __init__(self, language: str) -> None:
+            self.language = language
+
+        def __ror__(self, mapping):
+            return FakeRunnable(
+                lambda rag_query: {
+                    "language": self.language,
+                    "context": mapping["context"].invoke(rag_query),
+                    "question": mapping["question"].invoke(rag_query),
+                }
+            )
+
+    monkeypatch.setattr(
+        "app.common.langchain_module.assistant_prompt",
+        lambda language: FakePrompt(language),
+    )
+
+    class FakeLLM:
+        def __ror__(self, previous):
+            return FakeRunnable(
+                lambda rag_query: f"fake_llm_response:{previous.invoke(rag_query)['question']}"
+            )
+
+    monkeypatch.setattr(
+        "app.common.langchain_module.Ollama",
+        lambda *args, **kwargs: FakeLLM(),
+    )
+
+    class FakeParser:
+        def __ror__(self, previous):
+            return FakeRunnable(lambda rag_query: previous.invoke(rag_query))
+
+    monkeypatch.setattr(
+        "app.common.langchain_module.StrOutputParser",
+        lambda: FakeParser(),
+    )
+
+    result = response(query)
+
+    assert result == "fake_llm_response:Hola necesito el informe trimestral"
+    assert fake_retriever.queries == [query]


### PR DESCRIPTION
## Summary
- limit greeting responses to queries with at most four detected words by using a real word count
- add a regression test that stubs the RAG pipeline to ensure longer greeting-like queries use the RAG path

## Testing
- pytest tests/test_langchain_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e721fbec8320b651ec1c25a65057