### PR TITLE
Make embeddings initialization lazy

### DIFF
--- a/app/pages/Archivos.py
+++ b/app/pages/Archivos.py
@@ -7,13 +7,6 @@ except ImportError:
     import sys
     sys.exit(1)
 
-try:
-    from langchain_community.embeddings import HuggingFaceEmbeddings  # type: ignore
-except ImportError:
-    print("Error: langchain_community module not found. Please install it with 'pip install langchain-community==0.0.34'")
-    import sys
-    sys.exit(1)
-
 import os
 
 try:
@@ -80,7 +73,6 @@ with st.sidebar:
         st.rerun()
 # Define the Chroma settings
 collection = CHROMA_SETTINGS.get_or_create_collection(name='vectordb')
-embeddings = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')
 
 st.title(get_text("files_title", st.session_state.language))
 st.caption(get_text("files_intro", st.session_state.language))


### PR DESCRIPTION
## Summary
- add a thread-safe `get_embeddings` helper in `app/common/ingest_file.py` so the HuggingFace model is created on demand
- switch ingestion logic to pull embeddings from the helper and expose it via `__all__`
- drop the unused global embeddings instantiation from the Archivos Streamlit page

## Testing
- pytest tests/converter/test_ingest_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e728594c83208bd69144dde47319