### PR TITLE
Cache HuggingFace embeddings in langchain module

### DIFF
--- a/tests/test_langchain_module.py
+++ b/tests/test_langchain_module.py
@@ -7,6 +7,128 @@ import pytest
 from app.common.langchain_module import detect_language, response
 
 
+class FakeRunnable:
+    def __init__(self, func):
+        self._func = func
+
+    def invoke(self, value):
+        return self._func(value)
+
+    def __call__(self, value):
+        return self._func(value)
+
+    def __or__(self, other):
+        if isinstance(other, FakeRunnable):
+            return FakeRunnable(lambda value: other.invoke(self.invoke(value)))
+        if callable(other):
+            return FakeRunnable(lambda value: other(self.invoke(value)))
+        return NotImplemented
+
+    def __ror__(self, other):
+        if isinstance(other, FakeRunnable):
+            return FakeRunnable(lambda value: self.invoke(other.invoke(value)))
+        if callable(other):
+            return FakeRunnable(lambda value: self.invoke(other(value)))
+        return NotImplemented
+
+
+class FakeRetriever:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def __call__(self, rag_query: str):
+        self.queries.append(rag_query)
+        return [SimpleNamespace(page_content="Contexto simulado")]
+
+    def __or__(self, formatter):
+        return FakeRunnable(lambda rag_query: formatter(self(rag_query)))
+
+
+class FakePrompt:
+    def __init__(self, language: str) -> None:
+        self.language = language
+
+    def __ror__(self, mapping):
+        return FakeRunnable(
+            lambda rag_query: {
+                "language": self.language,
+                "context": mapping["context"].invoke(rag_query),
+                "question": mapping["question"].invoke(rag_query),
+            }
+        )
+
+
+class FakeLLM:
+    def __ror__(self, previous):
+        return FakeRunnable(
+            lambda rag_query: f"fake_llm_response:{previous.invoke(rag_query)['question']}"
+        )
+
+
+class FakeParser:
+    def __ror__(self, previous):
+        return FakeRunnable(lambda rag_query: previous.invoke(rag_query))
+
+
+def _configure_rag_environment(
+    monkeypatch: pytest.MonkeyPatch, *, embeddings_factory
+) -> tuple[list[FakeRetriever], list[object]]:
+    def fake_get_text(key: str, language: str, **_: object) -> str:
+        return f"{key}:{language}"
+
+    monkeypatch.setattr("app.common.langchain_module.get_text", fake_get_text)
+    monkeypatch.setattr(
+        "app.common.langchain_module.parse_arguments",
+        lambda: SimpleNamespace(hide_source=False, mute_stream=True),
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.record_rag_response",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.HuggingFaceEmbeddings", embeddings_factory
+    )
+
+    class FakeCollection:
+        def count(self) -> int:
+            return 2
+
+    fake_client = SimpleNamespace(
+        get_collection=lambda name: FakeCollection(),
+    )
+    monkeypatch.setattr("app.common.langchain_module.CHROMA_SETTINGS", fake_client)
+
+    created_retrievers: list[FakeRetriever] = []
+    chroma_embeddings: list[object] = []
+
+    class FakeChroma:
+        def __init__(self, *_, embedding_function=None, **__):
+            self.retriever = FakeRetriever()
+            created_retrievers.append(self.retriever)
+            chroma_embeddings.append(embedding_function)
+
+        def as_retriever(self, **_):
+            return self.retriever
+
+    monkeypatch.setattr("app.common.langchain_module.Chroma", FakeChroma)
+    monkeypatch.setattr(
+        "app.common.langchain_module.RunnablePassthrough",
+        lambda: FakeRunnable(lambda value: value),
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.assistant_prompt",
+        lambda language: FakePrompt(language),
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.Ollama", lambda *args, **kwargs: FakeLLM()
+    )
+    monkeypatch.setattr(
+        "app.common.langchain_module.StrOutputParser", lambda: FakeParser()
+    )
+
+    return created_retrievers, chroma_embeddings
+
+
 @pytest.mark.parametrize(
     "text, expected",
     [
@@ -52,123 +174,41 @@ def test_response_long_greeting_invokes_rag(monkeypatch: pytest.MonkeyPatch) -> 
     """Consultas largas deben evitar la rama de saludos y ejecutar el flujo de RAG."""
 
     query = "Hola necesito el informe trimestral"
+    monkeypatch.setattr("app.common.langchain_module._embeddings_instance", None)
 
-    def fake_get_text(key: str, language: str, **_: object) -> str:
-        return f"{key}:{language}"
-
-    monkeypatch.setattr("app.common.langchain_module.get_text", fake_get_text)
-    monkeypatch.setattr(
-        "app.common.langchain_module.parse_arguments",
-        lambda: SimpleNamespace(hide_source=False, mute_stream=True),
-    )
-    monkeypatch.setattr(
-        "app.common.langchain_module.HuggingFaceEmbeddings",
-        lambda model_name: SimpleNamespace(model_name=model_name),
-    )
-    monkeypatch.setattr(
-        "app.common.langchain_module.record_rag_response",
-        lambda *args, **kwargs: None,
-    )
-
-    class FakeCollection:
-        def count(self) -> int:
-            return 2
-
-    fake_client = SimpleNamespace(
-        get_collection=lambda name: FakeCollection(),
-    )
-    monkeypatch.setattr("app.common.langchain_module.CHROMA_SETTINGS", fake_client)
-
-    class FakeRunnable:
-        def __init__(self, func):
-            self._func = func
-
-        def invoke(self, value):
-            return self._func(value)
-
-        def __call__(self, value):
-            return self._func(value)
-
-        def __or__(self, other):
-            if isinstance(other, FakeRunnable):
-                return FakeRunnable(lambda value: other.invoke(self.invoke(value)))
-            if callable(other):
-                return FakeRunnable(lambda value: other(self.invoke(value)))
-            return NotImplemented
-
-        def __ror__(self, other):
-            if isinstance(other, FakeRunnable):
-                return FakeRunnable(lambda value: self.invoke(other.invoke(value)))
-            if callable(other):
-                return FakeRunnable(lambda value: self.invoke(other(value)))
-            return NotImplemented
-
-    class FakeRetriever:
-        def __init__(self) -> None:
-            self.queries: list[str] = []
-
-        def __call__(self, rag_query: str):
-            self.queries.append(rag_query)
-            return [SimpleNamespace(page_content="Contexto simulado")]
-
-        def __or__(self, formatter):
-            return FakeRunnable(lambda rag_query: formatter(self(rag_query)))
-
-    fake_retriever = FakeRetriever()
-
-    class FakeChroma:
-        def __init__(self, *_, **__):
-            pass
-
-        def as_retriever(self, **_):
-            return fake_retriever
-
-    monkeypatch.setattr("app.common.langchain_module.Chroma", FakeChroma)
-
-    monkeypatch.setattr(
-        "app.common.langchain_module.RunnablePassthrough",
-        lambda: FakeRunnable(lambda value: value),
-    )
-
-    class FakePrompt:
-        def __init__(self, language: str) -> None:
-            self.language = language
-
-        def __ror__(self, mapping):
-            return FakeRunnable(
-                lambda rag_query: {
-                    "language": self.language,
-                    "context": mapping["context"].invoke(rag_query),
-                    "question": mapping["question"].invoke(rag_query),
-                }
-            )
-
-    monkeypatch.setattr(
-        "app.common.langchain_module.assistant_prompt",
-        lambda language: FakePrompt(language),
-    )
-
-    class FakeLLM:
-        def __ror__(self, previous):
-            return FakeRunnable(
-                lambda rag_query: f"fake_llm_response:{previous.invoke(rag_query)['question']}"
-            )
-
-    monkeypatch.setattr(
-        "app.common.langchain_module.Ollama",
-        lambda *args, **kwargs: FakeLLM(),
-    )
-
-    class FakeParser:
-        def __ror__(self, previous):
-            return FakeRunnable(lambda rag_query: previous.invoke(rag_query))
-
-    monkeypatch.setattr(
-        "app.common.langchain_module.StrOutputParser",
-        lambda: FakeParser(),
+    retrievers, _ = _configure_rag_environment(
+        monkeypatch,
+        embeddings_factory=lambda model_name: SimpleNamespace(model_name=model_name),
     )
 
     result = response(query)
 
     assert result == "fake_llm_response:Hola necesito el informe trimestral"
-    assert fake_retriever.queries == [query]
+    assert retrievers[-1].queries == [query]
+
+
+def test_response_reuses_embeddings_instance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """El helper ``get_embeddings`` debe inicializar el modelo una única vez."""
+
+    query = "Hola necesito el informe trimestral"
+    monkeypatch.setattr("app.common.langchain_module._embeddings_instance", None)
+
+    instantiations: list[str] = []
+
+    def fake_embeddings(model_name: str):
+        instantiations.append(model_name)
+        return SimpleNamespace(model_name=model_name)
+
+    retrievers, chroma_embeddings = _configure_rag_environment(
+        monkeypatch, embeddings_factory=fake_embeddings
+    )
+
+    first_result = response(query)
+    second_result = response(query)
+
+    assert first_result == "fake_llm_response:Hola necesito el informe trimestral"
+    assert second_result == "fake_llm_response:Hola necesito el informe trimestral"
+    assert len(instantiations) == 1
+    assert len(chroma_embeddings) == 2
+    assert chroma_embeddings[0] is chroma_embeddings[1]
+    assert all(retriever.queries == [query] for retriever in retrievers)


### PR DESCRIPTION
## Summary
- add a cached helper that initialises HuggingFaceEmbeddings once and reuses it across calls
- update the response pipeline to use the shared embeddings instance instead of constructing it every time
- extend langchain module tests to share RAG fakes and verify the embeddings are created only once with repeated calls

## Testing
- pytest tests/test_langchain_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d0ecbb97f483208b324a137d9295ef