### PR TITLE
Avoid reloading langchain module in Inicio

### DIFF
--- a/app/Inicio.py
+++ b/app/Inicio.py
@@ -11,10 +11,7 @@ except ImportError:
 
 # Try to import the required modules, and if they fail, provide helpful error messages
 try:
-    import importlib
-    import common.langchain_module as langchain_module
-    langchain_module = importlib.reload(langchain_module)
-    response = langchain_module.response
+    from common.langchain_module import response
 except ImportError:
     print("Error: common.langchain_module module not found. Make sure the module exists and is in the Python path.")
     import sys

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,3 +34,10 @@ pytest -m slow
 ```
 
 Si deseas excluirlas durante desarrollos rápidos puedes usar `pytest -m "not slow"`.
+
+## Historial de pruebas
+
+- Se añadió una prueba unitaria que verifica que importar la página `Inicio`
+  en Streamlit no reinicia la caché de embeddings: el objeto
+  `_embeddings_instance` de `common.langchain_module` se conserva entre
+  interacciones.

--- a/tests/client/test_inicio_embeddings_cache.py
+++ b/tests/client/test_inicio_embeddings_cache.py
@@ -1,0 +1,109 @@
+"""Tests for the Streamlit home page module."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _install_streamlit_stub(monkeypatch) -> None:
+    """Register a lightweight ``streamlit`` stub for module imports."""
+
+    class _SessionState(dict):
+        def __getattr__(self, name: str):  # noqa: D401 - simple proxy
+            try:
+                return self[name]
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise AttributeError(name) from exc
+
+        def __setattr__(self, name: str, value) -> None:  # noqa: D401 - simple proxy
+            self[name] = value
+
+    class _Sidebar:
+        def __enter__(self) -> "_Sidebar":  # noqa: D401 - context protocol
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401 - context protocol
+            return False
+
+        def title(self, *args, **kwargs) -> None:  # noqa: D401 - optional API compatibility
+            return None
+
+        def caption(self, *args, **kwargs) -> None:  # noqa: D401 - optional API compatibility
+            return None
+
+        def selectbox(self, *args, **kwargs):  # noqa: D401 - optional API compatibility
+            return _selectbox(*args, **kwargs)
+
+    class _ChatMessage:
+        def __init__(self, role: str) -> None:
+            self.role = role
+
+        def __enter__(self) -> "_ChatMessage":  # noqa: D401 - context protocol
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401 - context protocol
+            return False
+
+        def markdown(self, *args, **kwargs) -> None:  # noqa: D401 - mimic Streamlit API
+            return None
+
+    class _Spinner:
+        def __init__(self, message: object) -> None:
+            self.message = message
+
+        def __enter__(self) -> "_Spinner":  # noqa: D401 - context protocol
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:  # noqa: D401 - context protocol
+            return False
+
+    def _selectbox(label, options, format_func=lambda value: value, index=0, help=None):
+        del label, format_func, help
+        if not options:
+            return None
+        if not isinstance(index, int) or index < 0 or index >= len(options):
+            index = 0
+        return options[index]
+
+    streamlit_module = types.ModuleType("streamlit")
+    streamlit_module.session_state = _SessionState()
+    streamlit_module.set_page_config = lambda *args, **kwargs: None
+    streamlit_module.sidebar = _Sidebar()
+    streamlit_module.title = lambda *args, **kwargs: None
+    streamlit_module.caption = lambda *args, **kwargs: None
+    streamlit_module.markdown = lambda *args, **kwargs: None
+    streamlit_module.selectbox = _selectbox
+    streamlit_module.chat_message = lambda role: _ChatMessage(str(role))
+    streamlit_module.chat_input = lambda *args, **kwargs: None
+    streamlit_module.spinner = lambda message: _Spinner(message)
+    streamlit_module.error = lambda *args, **kwargs: None
+    streamlit_module.rerun = lambda: None
+
+    monkeypatch.setitem(sys.modules, "streamlit", streamlit_module)
+
+
+def test_inicio_preserves_cached_embeddings(monkeypatch) -> None:
+    """Importing ``Inicio`` must keep the cached embeddings instance intact."""
+
+    _install_streamlit_stub(monkeypatch)
+
+    import common.langchain_module as langchain_module
+
+    previous_instance = langchain_module._embeddings_instance
+    sentinel_instance = object()
+    langchain_module._embeddings_instance = sentinel_instance
+
+    module_name = "Inicio"
+    existing_module = sys.modules.pop(module_name, None)
+
+    try:
+        importlib.import_module(module_name)
+        assert langchain_module._embeddings_instance is sentinel_instance
+    finally:
+        langchain_module._embeddings_instance = previous_instance
+        if existing_module is not None:
+            sys.modules[module_name] = existing_module
+        else:
+            sys.modules.pop(module_name, None)


### PR DESCRIPTION
## Summary
- stop reloading `common.langchain_module` in the Streamlit home page and rely on the cached `response` function
- add a regression test that stubs Streamlit and ensures importing `Inicio` keeps the cached embeddings instance
- document the new regression in the testing history

## Testing
- pytest tests/client/test_inicio_embeddings_cache.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f54f63108320b2d8614c8fe8eb8f