### PR TITLE
Handle multi-collection retrieval and update tests

### DIFF
--- a/app/common/langchain_module.py
+++ b/app/common/langchain_module.py
@@ -14,14 +14,51 @@ except ImportError:
     import sys
     sys.exit(1)
 
+RunnableLambda = None  # type: ignore[assignment]
+
 try:
     from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
     from langchain_core.output_parsers import StrOutputParser
     from langchain_core.runnables import RunnablePassthrough
+    try:
+        from langchain_core.runnables import RunnableLambda as _RunnableLambda
+    except ImportError:
+        _RunnableLambda = None
+    else:
+        RunnableLambda = _RunnableLambda
 except ImportError:
     print("Error: langchain_core module not found. Please install it with 'pip install langchain-core'")
     import sys
     sys.exit(1)
+
+if RunnableLambda is None:  # pragma: no cover - fallback for older langchain versions
+    class _CallableRunnable:
+        def __init__(self, func):
+            self._func = func
+
+        def invoke(self, value):
+            return self._func(value)
+
+        def __call__(self, value):
+            return self._func(value)
+
+        def __or__(self, other):
+            if hasattr(other, "invoke"):
+                return _CallableRunnable(lambda value: other.invoke(self.invoke(value)))
+            if callable(other):
+                return _CallableRunnable(lambda value: other(self.invoke(value)))
+            return NotImplemented
+
+        def __ror__(self, other):
+            if hasattr(other, "invoke"):
+                return _CallableRunnable(lambda value: self.invoke(other.invoke(value)))
+            if callable(other):
+                return _CallableRunnable(lambda value: self.invoke(other(value)))
+            return NotImplemented
+
+    class RunnableLambda(_CallableRunnable):
+        """Ligero reemplazo de ``RunnableLambda`` cuando la dependencia no lo expone."""
+
 
 try:
     from common.chroma_db_settings import Chroma
@@ -55,7 +92,7 @@ import argparse
 import logging
 import time
 from threading import Lock
-from typing import Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 # Configurar logging
 logging.basicConfig(
@@ -71,7 +108,7 @@ model = os.environ.get("MODEL")
 embeddings_model_name = os.environ.get("EMBEDDINGS_MODEL_NAME", "all-MiniLM-L6-v2")
 target_source_chunks = int(os.environ.get('TARGET_SOURCE_CHUNKS',5))
 
-from common.constants import CHROMA_SETTINGS
+from common.constants import CHROMA_COLLECTIONS, CHROMA_SETTINGS
 from common.observability import record_rag_response
 
 
@@ -223,22 +260,131 @@ def response(query: str, language: Optional[str] = None) -> str:
 
         embeddings = get_embeddings()
 
-        db = Chroma(client=CHROMA_SETTINGS, embedding_function=embeddings)
+        per_collection_counts: Dict[str, int] = {
+            name: 0 for name in CHROMA_COLLECTIONS
+        }
+        retrievers_by_collection: List[Tuple[str, Any]] = []
+        total_documents = 0
 
-        # Verificar si hay documentos en la base de datos
-        try:
-            collection = CHROMA_SETTINGS.get_collection('vectordb')
-            doc_count = collection.count()
-            available_documents = doc_count
-            logger.info(f"Documentos en la base de conocimiento: {doc_count}")
+        for collection_name in CHROMA_COLLECTIONS:
+            try:
+                collection = CHROMA_SETTINGS.get_collection(collection_name)
+            except Exception as exc:
+                logger.warning(
+                    "No se pudo obtener la colección '%s': %s",
+                    collection_name,
+                    exc,
+                )
+                continue
+
+            try:
+                doc_count = collection.count()
+            except Exception as exc:
+                logger.warning(
+                    "No se pudo verificar la cantidad de documentos en '%s': %s",
+                    collection_name,
+                    exc,
+                )
+                continue
+
+            per_collection_counts[collection_name] = doc_count
+            total_documents += doc_count
 
             if doc_count == 0:
-                status = "empty"
-                return _translate("no_documents", language_code)
-        except Exception as e:
-            logger.warning(f"No se pudo verificar la cantidad de documentos: {e}")
+                continue
 
-        retriever = db.as_retriever(search_kwargs={"k": target_source_chunks})
+            try:
+                vector_store = Chroma(
+                    client=CHROMA_SETTINGS,
+                    collection_name=collection_name,
+                    embedding_function=embeddings,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "No se pudo inicializar el vectorstore para '%s': %s",
+                    collection_name,
+                    exc,
+                )
+                continue
+
+            retriever = vector_store.as_retriever(
+                search_kwargs={"k": target_source_chunks}
+            )
+            retrievers_by_collection.append((collection_name, retriever))
+
+        available_documents = total_documents
+        logger.info(
+            "Documentos en la base de conocimiento por colección: %s",
+            ", ".join(
+                f"{name}:{per_collection_counts.get(name, 0)}"
+                for name in CHROMA_COLLECTIONS
+            ),
+        )
+
+        if total_documents == 0:
+            status = "empty"
+            return _translate("no_documents", language_code)
+
+        def _document_priority(doc: Any) -> Tuple[int, float]:
+            metadata = getattr(doc, "metadata", {}) or {}
+            distance = metadata.get("distance")
+            if isinstance(distance, (int, float)):
+                return (0, float(distance))
+
+            score = metadata.get("score")
+            if isinstance(score, (int, float)):
+                return (1, -float(score))
+
+            similarity = metadata.get("similarity")
+            if isinstance(similarity, (int, float)):
+                return (1, -float(similarity))
+
+            return (2, 0.0)
+
+        def collect_documents(rag_query: str) -> List[Any]:
+            aggregated: List[Any] = []
+
+            for collection_name, retriever in retrievers_by_collection:
+                try:
+                    results = retriever.invoke(rag_query)
+                except AttributeError:
+                    try:
+                        results = retriever.get_relevant_documents(rag_query)
+                    except Exception as retrieval_error:  # pragma: no cover - defensive
+                        logger.warning(
+                            "No se pudo recuperar documentos de la colección '%s': %s",
+                            collection_name,
+                            retrieval_error,
+                        )
+                        continue
+                except Exception as retrieval_error:
+                    logger.warning(
+                        "No se pudo recuperar documentos de la colección '%s': %s",
+                        collection_name,
+                        retrieval_error,
+                    )
+                    continue
+
+                if not results:
+                    continue
+
+                for doc in results:
+                    metadata = getattr(doc, "metadata", None)
+                    if isinstance(metadata, dict):
+                        metadata.setdefault("collection", collection_name)
+                    aggregated.append(doc)
+
+            if not aggregated:
+                return []
+
+            scored_docs: List[Tuple[int, Any, Tuple[int, float]]] = [
+                (index, doc, _document_priority(doc))
+                for index, doc in enumerate(aggregated)
+            ]
+
+            scored_docs.sort(key=lambda item: (item[2][0], item[2][1], item[0]))
+            return [doc for _, doc, _ in scored_docs[:target_source_chunks]]
+
         # activate/deactivate the streaming StdOut callback for LLMs
         callbacks = [] if args.mute_stream else [StreamingStdOutCallbackHandler()]
 
@@ -255,8 +401,10 @@ def response(query: str, language: Optional[str] = None) -> str:
             context_document_count = len(docs)
             return "\n\n".join(doc.page_content for doc in docs)
 
+        multi_retriever = RunnableLambda(collect_documents)
+
         rag_chain = (
-            {"context": retriever | format_docs, "question": RunnablePassthrough()}
+            {"context": multi_retriever | format_docs, "question": RunnablePassthrough()}
             | prompt
             | llm
             | StrOutputParser()


### PR DESCRIPTION
## Summary
- iterate over the configured Chroma collections, summing document counts and aggregating retrieved chunks before building the prompt
- add a lightweight RunnableLambda fallback so the module works even if langchain-core lacks the helper
- expand the langchain module tests to exercise multi-collection scenarios and ensure retrievers are instantiated per collection

## Testing
- pytest tests/test_langchain_module.py

------
https://chatgpt.com/codex/tasks/task_e_68d105af69ec832093d6a330d874148a