### PR TITLE
Summarise Chroma file listing via metadata

### DIFF
--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -515,7 +515,7 @@ async def list_documents(token: str = Depends(verify_token)):
         from common.constants import CHROMA_SETTINGS
 
         files_df = get_unique_sources_df(CHROMA_SETTINGS)
-        documents = files_df['Archivo'].tolist() if not files_df.empty else []
+        documents = files_df['uploaded_file_name'].tolist() if not files_df.empty else []
         
         return {
             "status": "success",

--- a/app/common/i18n/en.yml
+++ b/app/common/i18n/en.yml
@@ -31,6 +31,9 @@ file_uploader_help: "Supported formats: {extensions}. Use Enter or Space to open
 file_uploader_caption: "Files are stored securely in the project container."
 add_to_knowledge_base_help: "Validates and ingests the selected file into the knowledge base."
 files_table_help: "Use the arrow keys to move across the grid. Press Space to toggle the delete checkbox."
+files_column_file: "File"
+files_column_domain: "Domain"
+files_column_collection: "Collection"
 delete_file_help: "Confirm the file name and metadata before deleting it from the knowledge base."
 delete_confirmation_help: "Deletes the selected file from the knowledge base after confirmation."
 

--- a/app/common/i18n/es.yml
+++ b/app/common/i18n/es.yml
@@ -31,6 +31,9 @@ file_uploader_help: "Formatos admitidos: {extensions}. Usa Enter o la barra espa
 file_uploader_caption: "Los archivos se almacenan de forma segura en el contenedor del proyecto."
 add_to_knowledge_base_help: "Valida e ingiere el archivo seleccionado en la base de conocimiento."
 files_table_help: "Usa las flechas para moverte por la tabla. Presiona la barra espaciadora para marcar o desmarcar la casilla de eliminación."
+files_column_file: "Archivo"
+files_column_domain: "Dominio"
+files_column_collection: "Colección"
 delete_file_help: "Verifica el nombre y los metadatos del archivo antes de eliminarlo de la base de conocimiento."
 delete_confirmation_help: "Elimina el archivo seleccionado de la base de conocimiento tras la confirmación."
 

--- a/tests/pages/test_files_listing.py
+++ b/tests/pages/test_files_listing.py
@@ -1,0 +1,205 @@
+"""Tests for the Archivos page data helpers."""
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import types
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import pytest
+
+
+def _install_langchain_stubs(monkeypatch) -> None:
+    """Provide minimal stand-ins for optional langchain dependencies."""
+
+    if "langchain_core.documents" in sys.modules:  # pragma: no cover - respect real modules
+        return
+
+    langchain_core = types.ModuleType("langchain_core")
+
+    documents_module = types.ModuleType("langchain_core.documents")
+    documents_module.Document = object  # type: ignore[attr-defined]
+
+    embeddings_module = types.ModuleType("langchain_core.embeddings")
+    embeddings_module.Embeddings = object  # type: ignore[attr-defined]
+
+    utils_module = types.ModuleType("langchain_core.utils")
+
+    def _xor_args(*_args, **_kwargs):  # type: ignore[override]
+        def _decorator(func):
+            return func
+
+        return _decorator
+
+    utils_module.xor_args = _xor_args  # type: ignore[attr-defined]
+
+    vectorstores_module = types.ModuleType("langchain_core.vectorstores")
+    vectorstores_module.VectorStore = object  # type: ignore[attr-defined]
+
+    langchain_core.documents = documents_module  # type: ignore[attr-defined]
+    langchain_core.embeddings = embeddings_module  # type: ignore[attr-defined]
+    langchain_core.utils = utils_module  # type: ignore[attr-defined]
+    langchain_core.vectorstores = vectorstores_module  # type: ignore[attr-defined]
+
+    community_module = sys.modules.get("langchain_community", types.ModuleType("langchain_community"))
+    vectorstores_pkg = sys.modules.get(
+        "langchain_community.vectorstores", types.ModuleType("langchain_community.vectorstores")
+    )
+    utils_submodule = types.ModuleType("langchain_community.vectorstores.utils")
+
+    def _maximal_marginal_relevance(*_args, **_kwargs):  # type: ignore[override]
+        return []
+
+    utils_submodule.maximal_marginal_relevance = _maximal_marginal_relevance  # type: ignore[attr-defined]
+    vectorstores_pkg.utils = utils_submodule  # type: ignore[attr-defined]
+    community_module.vectorstores = vectorstores_pkg  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "langchain_core", langchain_core)
+    monkeypatch.setitem(sys.modules, "langchain_core.documents", documents_module)
+    monkeypatch.setitem(sys.modules, "langchain_core.embeddings", embeddings_module)
+    monkeypatch.setitem(sys.modules, "langchain_core.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "langchain_core.vectorstores", vectorstores_module)
+    monkeypatch.setitem(sys.modules, "langchain_community", community_module)
+    monkeypatch.setitem(sys.modules, "langchain_community.vectorstores", vectorstores_pkg)
+    monkeypatch.setitem(
+        sys.modules, "langchain_community.vectorstores.utils", utils_submodule
+    )
+
+
+@dataclass
+class _FakeCollection:
+    """Minimal double mimicking a Chroma collection."""
+
+    metadatas: List[Optional[Dict[str, str]]]
+    requested_includes: List[Optional[Iterable[str]]] = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple initialiser
+        if self.requested_includes is None:
+            self.requested_includes = []
+
+    class _MetadataResponse:
+        def __init__(self, metadatas: List[Optional[Dict[str, str]]]):
+            self._metadatas = metadatas
+
+        def get(self, key: str, default=None):  # pragma: no cover - trivial
+            if key != "metadatas":
+                raise AssertionError(f"Unexpected key requested: {key}")
+            return self._metadatas
+
+    def get(self, include: Optional[Iterable[str]] = None):
+        self.requested_includes.append(list(include) if include is not None else None)
+        if include != ["metadatas"]:
+            raise AssertionError(f"Expected include=['metadatas'], received: {include}")
+        return self._MetadataResponse(self.metadatas)
+
+
+class _FakeChromaClient:
+    def __init__(self, collections: Dict[str, _FakeCollection]):
+        self._collections = collections
+
+    def get_or_create_collection(self, name: str) -> _FakeCollection:
+        return self._collections[name]
+
+
+@dataclass(frozen=True)
+class _CollectionConfig:
+    domain: str
+    description: str = ""
+
+
+def _expected_records(
+    metadata: Dict[str, List[Optional[Dict[str, str]]]],
+    configs: Dict[str, _CollectionConfig],
+) -> set[tuple[str, str, str]]:
+    expected: set[tuple[str, str, str]] = set()
+    for collection_name, metadatas in metadata.items():
+        config = configs[collection_name]
+        for entry in metadatas:
+            if not entry:
+                continue
+            file_name = entry.get("uploaded_file_name")
+            if not file_name:
+                source = entry.get("source")
+                if source:
+                    file_name = os.path.basename(source)
+            if not file_name:
+                continue
+            domain = entry.get("domain") or config.domain
+            collection = entry.get("collection") or collection_name
+            expected.add((file_name, domain, collection))
+    return expected
+
+
+def test_get_unique_sources_df_uses_metadata_only(monkeypatch, request: pytest.FixtureRequest):
+    """Large collections should be summarised using metadata only."""
+
+    _install_langchain_stubs(monkeypatch)
+    module_name = "app.common.chroma_db_settings"
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    chroma_module = importlib.import_module(module_name)
+    request.addfinalizer(lambda: sys.modules.pop(module_name, None))
+
+    configs = {
+        "alpha_docs": _CollectionConfig(domain="documents", description="Alpha"),
+        "beta_code": _CollectionConfig(domain="code", description="Beta"),
+    }
+    monkeypatch.setattr(chroma_module, "CHROMA_COLLECTIONS", configs, raising=True)
+
+    alpha_metadatas = [
+        {"uploaded_file_name": f"alpha_{index}.pdf", "domain": "documents"}
+        for index in range(150)
+    ]
+    alpha_metadatas.extend(
+        [
+            {"uploaded_file_name": "shared.txt", "collection": "alpha_docs"},
+            {"uploaded_file_name": "alpha_1.pdf"},  # duplicate to verify dedupe
+            {},
+        ]
+    )
+
+    beta_metadatas = [
+        {"uploaded_file_name": f"beta_{index}.md"} for index in range(80)
+    ]
+    beta_metadatas.extend(
+        [
+            {"source": "/opt/records/fallback.log"},
+            {"uploaded_file_name": "shared.txt", "collection": "custom_beta"},
+            None,
+        ]
+    )
+
+    fake_collections = {
+        "alpha_docs": _FakeCollection(alpha_metadatas),
+        "beta_code": _FakeCollection(beta_metadatas),
+    }
+
+    client = _FakeChromaClient(fake_collections)
+
+    df = chroma_module.get_unique_sources_df(client)
+
+    assert list(df.columns) == ["uploaded_file_name", "domain", "collection"]
+    assert len(df) == len(_expected_records({
+        "alpha_docs": alpha_metadatas,
+        "beta_code": beta_metadatas,
+    }, configs))
+    assert len(df) > 150  # Ensure we handle large collections without truncation
+
+    # Ensure only metadata was requested from every collection
+    for fake_collection in fake_collections.values():
+        assert fake_collection.requested_includes == [["metadatas"]]
+
+    expected = _expected_records({
+        "alpha_docs": alpha_metadatas,
+        "beta_code": beta_metadatas,
+    }, configs)
+    observed = {
+        tuple(row)
+        for row in df[["uploaded_file_name", "domain", "collection"]].itertuples(index=False, name=None)
+    }
+    assert observed == expected
+
+    # Spot-check that fallbacks worked correctly
+    assert "fallback.log" in df["uploaded_file_name"].values
+    assert (df["collection"] == "custom_beta").sum() == 1


### PR DESCRIPTION
## Summary
- update `get_unique_sources_df` to scan every configured Chroma collection using metadata-only queries
- adjust the Archivos page, API endpoint, and translations to display file, domain, and collection for each stored document
- add a regression test covering large collections to ensure only metadatas are fetched and deduplicated

## Testing
- `pytest tests/pages/test_files_listing.py`


------
https://chatgpt.com/codex/tasks/task_e_68d105b5ae7483208dd4a26d192095da