### PR TITLE
Limit file listing to metadata retrieval

### DIFF
--- a/app/api_endpoints.py
+++ b/app/api_endpoints.py
@@ -511,8 +511,8 @@ async def upload_document(
 async def list_documents(token: str = Depends(verify_token)):
     """Obtiene el catálogo de documentos actualmente indexados."""
     try:
-        from common.chroma_db_settings import get_unique_sources_df
         from common.constants import CHROMA_SETTINGS
+        from common.ingest_file import get_unique_sources_df
 
         files_df = get_unique_sources_df(CHROMA_SETTINGS)
         documents = files_df['uploaded_file_name'].tolist() if not files_df.empty else []

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -92,6 +92,8 @@ def api_client_factory(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], TestC
 
                 return _StubSeries()
 
+        ingest_stub.get_unique_sources_df = lambda *args, **kwargs: _StubDataFrame()
+
         chroma_stub = types.ModuleType("common.chroma_db_settings")
         chroma_stub.get_unique_sources_df = lambda *args, **kwargs: _StubDataFrame()
         monkeypatch.setitem(sys.modules, "common.chroma_db_settings", chroma_stub)


### PR DESCRIPTION
## Summary
- restrict `get_unique_sources_df` to pull only metadata from each Chroma collection and normalise file descriptors
- reuse the ingest helper when listing documents through the API and refresh the auth test stub
- cover the metadata-only path with a large fake Chroma client to ensure all collections are included without heavy queries

## Testing
- pytest tests/pages/test_files_listing.py tests/test_api_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68d110d754c08320ab31727a2528a3eb