### PR TITLE
Refactor agent ingestors into dedicated subpackages

### DIFF
--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,14 +1,43 @@
-"""Domain specific ingestion helpers."""
+"""Domain specific ingestion helpers and agent factories."""
 
-from .base import BaseFileIngestor
-from .code import CodeIngestor
-from .documents import DocumentIngestor, refresh_document_loaders
-from .multimedia import MultimediaIngestor
+from .base import AgentResponse, AgentTask, BaseAgent, BaseFileIngestor, LoaderConfig
+from .code_agent import CODE_COLLECTION, CodeIngestor, create_code_ingestor
+from .document_agent import (
+    DOCUMENTS_COLLECTION,
+    DocumentAgent,
+    DocumentIngestor,
+    EmailFallbackLoader,
+    create_document_ingestor,
+    refresh_document_loaders,
+)
+from .media_agent import (
+    MULTIMEDIA_COLLECTION,
+    MediaAgent,
+    MultimediaIngestor,
+    create_multimedia_ingestor,
+)
+from .orchestrator import OrchestratorService, create_default_orchestrator, document_query_flow
 
 __all__ = [
+    "AgentResponse",
+    "AgentTask",
+    "BaseAgent",
     "BaseFileIngestor",
-    "DocumentIngestor",
+    "CODE_COLLECTION",
     "CodeIngestor",
+    "DOCUMENTS_COLLECTION",
+    "DocumentAgent",
+    "DocumentIngestor",
+    "EmailFallbackLoader",
+    "LoaderConfig",
+    "MULTIMEDIA_COLLECTION",
+    "MediaAgent",
     "MultimediaIngestor",
+    "OrchestratorService",
+    "create_code_ingestor",
+    "create_default_orchestrator",
+    "create_document_ingestor",
+    "create_multimedia_ingestor",
+    "document_query_flow",
     "refresh_document_loaders",
 ]

--- a/app/agents/code_agent/__init__.py
+++ b/app/agents/code_agent/__init__.py
@@ -1,0 +1,9 @@
+"""Helpers and ingestors for code-oriented workflows."""
+
+from .ingestor import CODE_COLLECTION, CodeIngestor, create_code_ingestor
+
+__all__ = [
+    "CODE_COLLECTION",
+    "CodeIngestor",
+    "create_code_ingestor",
+]

--- a/app/agents/code_agent/ingestor.py
+++ b/app/agents/code_agent/ingestor.py
@@ -16,7 +16,7 @@ except Exception:  # pragma: no cover - fallback loader for tests
             with open(self.file_path, "r", encoding=self.encoding) as handle:
                 return [Document(page_content=handle.read(), metadata={"source": self.file_path})]
 
-from .base import BaseFileIngestor
+from ..base import BaseFileIngestor
 
 CODE_LOADERS = {
     ".py": (TextLoader, {"encoding": "utf8"}),
@@ -45,4 +45,8 @@ def create_code_ingestor() -> BaseFileIngestor:
 
 CodeIngestor = create_code_ingestor()
 
-__all__ = ["CodeIngestor", "create_code_ingestor", "CODE_COLLECTION"]
+__all__ = [
+    "CODE_COLLECTION",
+    "CodeIngestor",
+    "create_code_ingestor",
+]

--- a/app/agents/document_agent/__init__.py
+++ b/app/agents/document_agent/__init__.py
@@ -1,5 +1,19 @@
 """Implementaciones especializadas para consultas sobre documentos."""
 
 from .agent import DocumentAgent
+from .ingestor import (
+    DOCUMENTS_COLLECTION,
+    DocumentIngestor,
+    EmailFallbackLoader,
+    create_document_ingestor,
+    refresh_document_loaders,
+)
 
-__all__ = ["DocumentAgent"]
+__all__ = [
+    "DOCUMENTS_COLLECTION",
+    "DocumentAgent",
+    "DocumentIngestor",
+    "EmailFallbackLoader",
+    "create_document_ingestor",
+    "refresh_document_loaders",
+]

--- a/app/agents/document_agent/ingestor.py
+++ b/app/agents/document_agent/ingestor.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple
 
 from common.text_normalization import Document
 
-from .base import BaseFileIngestor
+from ..base import BaseFileIngestor
 
 
 PLAIN_TEXT_FALLBACK = False
@@ -150,4 +150,10 @@ def create_document_ingestor() -> BaseFileIngestor:
 
 DocumentIngestor = create_document_ingestor()
 
-__all__ = ["DocumentIngestor", "create_document_ingestor", "DOCUMENTS_COLLECTION"]
+__all__ = [
+    "DOCUMENTS_COLLECTION",
+    "DocumentIngestor",
+    "EmailFallbackLoader",
+    "create_document_ingestor",
+    "refresh_document_loaders",
+]

--- a/app/agents/media_agent/__init__.py
+++ b/app/agents/media_agent/__init__.py
@@ -1,5 +1,15 @@
 """Agente responsable de tareas básicas sobre contenidos multimedia."""
 
 from .agent import MediaAgent
+from .ingestor import (
+    MULTIMEDIA_COLLECTION,
+    MultimediaIngestor,
+    create_multimedia_ingestor,
+)
 
-__all__ = ["MediaAgent"]
+__all__ = [
+    "MULTIMEDIA_COLLECTION",
+    "MediaAgent",
+    "MultimediaIngestor",
+    "create_multimedia_ingestor",
+]

--- a/app/agents/media_agent/ingestor.py
+++ b/app/agents/media_agent/ingestor.py
@@ -15,7 +15,7 @@ except Exception:  # pragma: no cover - fallback loader for tests
             with open(self.file_path, "r", encoding=self.encoding) as handle:
                 return [Document(page_content=handle.read(), metadata={"source": self.file_path})]
 
-from .base import BaseFileIngestor
+from ..base import BaseFileIngestor
 
 MULTIMEDIA_LOADERS = {
     ".srt": (TextLoader, {"encoding": "utf8"}),
@@ -38,7 +38,7 @@ def create_multimedia_ingestor() -> BaseFileIngestor:
 MultimediaIngestor = create_multimedia_ingestor()
 
 __all__ = [
+    "MULTIMEDIA_COLLECTION",
     "MultimediaIngestor",
     "create_multimedia_ingestor",
-    "MULTIMEDIA_COLLECTION",
 ]

--- a/tests/converter/test_ingest_pipeline.py
+++ b/tests/converter/test_ingest_pipeline.py
@@ -34,7 +34,8 @@ def ingest_env(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
     for module_name in [
         "app.common.ingest_file",
-        "app.agents.documents",
+        "app.agents.document_agent",
+        "app.agents.document_agent.ingestor",
         "common.constants",
         "common.chroma_db_settings",
     ]:
@@ -244,7 +245,7 @@ def ingest_env(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
 
     module = importlib.import_module("app.common.ingest_file")
 
-    doc_module = importlib.import_module("app.agents.documents")
+    doc_module = importlib.import_module("app.agents.document_agent.ingestor")
     for ext, (loader_cls, loader_kwargs) in list(doc_module.DOCUMENT_LOADERS.items()):
         doc_module.DOCUMENT_LOADERS[ext] = (_make_loader(loader_cls.__name__), loader_kwargs)
     doc_module.DocumentIngestor = doc_module.create_document_ingestor()


### PR DESCRIPTION
## Summary
- move the document, multimedia, and code ingestor modules into dedicated agent subpackages
- re-export agent classes, factories, and collections from `app.agents` to preserve public imports
- refresh tests and ingestion pipeline fixtures to reference the new module layout

## Testing
- pytest tests/agents
- pytest tests/converter/test_ingest_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d193da59908320906ee262c5091cee