### PR TITLE
Add troubleshooting code agent and dynamic orchestrator registration

### DIFF
--- a/app/agents/code_agent/__init__.py
+++ b/app/agents/code_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Agent responsible for troubleshooting tasks over code snippets."""
+
+from .agent import CodeAgent
+
+__all__ = ["CodeAgent"]

--- a/app/agents/code_agent/agent.py
+++ b/app/agents/code_agent/agent.py
@@ -1,0 +1,173 @@
+"""Agent focused on troubleshooting workflows for code snippets and logs."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, Mapping, MutableMapping, Sequence
+
+from app.agents.base import AgentResponse, AgentTask, BaseAgent
+from app.agents.code import CODE_COLLECTION
+from app.common.observability import record_agent_invocation
+
+
+_ContextItem = Mapping[str, Any]
+_Retriever = Callable[[str, int], Sequence[_ContextItem]]
+_CollectionResolver = Callable[[str], Any]
+
+
+@dataclass(frozen=True)
+class CodeAgentConfig:
+    """Configuration options for :class:`CodeAgent`."""
+
+    collection_name: str = CODE_COLLECTION
+    max_results: int = 3
+
+
+class CodeAgent(BaseAgent):
+    """Retrieve troubleshooting content from the code knowledge base."""
+
+    SUPPORTED_TASKS = {"code_troubleshooting"}
+
+    def __init__(
+        self,
+        config: CodeAgentConfig | None = None,
+        retriever: _Retriever | None = None,
+        collection_resolver: _CollectionResolver | None = None,
+    ) -> None:
+        super().__init__(name="code_agent")
+        self._config = config or CodeAgentConfig()
+        self._retriever = retriever
+        if retriever is None:
+            self._collection_resolver = collection_resolver or self._default_collection_resolver
+        else:
+            self._collection_resolver = collection_resolver
+
+    def can_handle(self, task: AgentTask) -> bool:
+        return task.task_type in self.SUPPORTED_TASKS
+
+    def handle(self, task: AgentTask) -> AgentResponse:
+        query = task.get("query") or task.get("question")
+        limit = self._resolve_limit(task.get("limit"))
+        language = task.get("language")
+        language_label = str(language).strip() if isinstance(language, str) and language.strip() else None
+
+        start_time = time.perf_counter()
+
+        if not query:
+            record_agent_invocation(
+                self.name,
+                task.task_type,
+                "invalid",
+                duration_seconds=time.perf_counter() - start_time,
+                language=language_label,
+            )
+            return AgentResponse(success=False, error="query_missing")
+
+        try:
+            matches = self._retrieve_matches(str(query), limit)
+        except Exception:
+            record_agent_invocation(
+                self.name,
+                task.task_type,
+                "error",
+                duration_seconds=time.perf_counter() - start_time,
+                language=language_label,
+            )
+            return AgentResponse(success=False, error="code_collection_error")
+
+        record_agent_invocation(
+            self.name,
+            task.task_type,
+            "success",
+            duration_seconds=time.perf_counter() - start_time,
+            language=language_label,
+        )
+
+        normalised_matches = self._normalise_matches(matches)
+
+        return AgentResponse(
+            success=True,
+            data={
+                "collection": self._config.collection_name,
+                "matches": normalised_matches,
+            },
+            metadata={
+                "query": str(query),
+                "match_count": len(normalised_matches),
+                "language": language_label,
+            },
+        )
+
+    def _resolve_limit(self, raw_limit: Any) -> int:
+        if isinstance(raw_limit, int) and raw_limit > 0:
+            return raw_limit
+        if isinstance(raw_limit, str):
+            try:
+                parsed = int(raw_limit.strip())
+            except ValueError:
+                parsed = 0
+            if parsed > 0:
+                return parsed
+        return max(int(self._config.max_results), 1)
+
+    def _retrieve_matches(self, query: str, limit: int) -> Sequence[_ContextItem]:
+        if self._retriever is not None:
+            return self._retriever(query, limit)
+
+        resolver = self._collection_resolver
+        if resolver is None:
+            raise RuntimeError("collection_resolver_missing")
+
+        collection = resolver(self._config.collection_name)
+        raw_results = collection.query(query_texts=[query], n_results=max(limit, 1))
+        return self._convert_collection_results(raw_results)
+
+    def _normalise_matches(self, matches: Sequence[_ContextItem]) -> List[dict[str, Any]]:
+        normalised: List[dict[str, Any]] = []
+        for match in matches:
+            if isinstance(match, Mapping):
+                content = match.get("content")
+                metadata_value = match.get("metadata")
+            else:
+                content = match
+                metadata_value = None
+
+            if not isinstance(content, str):
+                content = "" if content is None else str(content)
+
+            metadata: MutableMapping[str, Any]
+            if isinstance(metadata_value, Mapping):
+                metadata = dict(metadata_value)
+            else:
+                metadata = {}
+            normalised.append({"content": content, "metadata": dict(metadata)})
+        return normalised
+
+    def _convert_collection_results(self, results: Mapping[str, Any]) -> Sequence[_ContextItem]:
+        documents = results.get("documents") or []
+        metadatas = results.get("metadatas") or []
+
+        if documents and isinstance(documents[0], list):
+            documents = documents[0]
+        if metadatas and isinstance(metadatas[0], list):
+            metadatas = metadatas[0]
+
+        converted: List[dict[str, Any]] = []
+        for index, content in enumerate(documents):
+            metadata: Mapping[str, Any]
+            if index < len(metadatas) and isinstance(metadatas[index], Mapping):
+                metadata = metadatas[index]
+            else:
+                metadata = {}
+            converted.append({"content": content, "metadata": dict(metadata)})
+        return converted
+
+    @staticmethod
+    def _default_collection_resolver(collection_name: str) -> Any:
+        from app.common.constants import CHROMA_SETTINGS
+
+        return CHROMA_SETTINGS.get_or_create_collection(collection_name)
+
+
+__all__ = ["CodeAgent", "CodeAgentConfig"]

--- a/app/agents/orchestrator/service.py
+++ b/app/agents/orchestrator/service.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import List, Sequence
+from importlib import import_module
+import inspect
+from typing import Callable, Iterable, List, Sequence, Type, Union
 
 from app.agents.base import AgentResponse, AgentTask, BaseAgent
+from app.agents.code_agent import CodeAgent
 from app.agents.document_agent import DocumentAgent
 from app.agents.media_agent import MediaAgent
 from common.observability import record_orchestrator_decision
@@ -14,16 +17,42 @@ from common.observability import record_orchestrator_decision
 class OrchestratorService:
     """Coordinate task delegation between the available agents."""
 
-    def __init__(self, agents: Sequence[BaseAgent] | None = None) -> None:
+    AgentConfig = Union[
+        BaseAgent,
+        Type[BaseAgent],
+        Callable[[], BaseAgent],
+        str,
+    ]
+
+    def __init__(
+        self,
+        agents: Sequence[BaseAgent] | None = None,
+        agent_configs: Sequence[AgentConfig] | None = None,
+    ) -> None:
         self._agents: "OrderedDict[str, BaseAgent]" = OrderedDict()
         if agents:
             for agent in agents:
                 self.register_agent(agent)
+        if agent_configs:
+            self.register_agents_from_config(agent_configs)
 
     def register_agent(self, agent: BaseAgent) -> None:
         """Register or update an agent implementation."""
 
         self._agents[agent.name] = agent
+
+    def register_agent_late(self, agent_config: AgentConfig) -> BaseAgent:
+        """Instantiate and register an agent from configuration at runtime."""
+
+        agent = self._build_agent(agent_config)
+        self.register_agent(agent)
+        return agent
+
+    def register_agents_from_config(self, configs: Iterable[AgentConfig]) -> None:
+        """Register multiple agents from configuration entries."""
+
+        for config in configs:
+            self.register_agent_late(config)
 
     def available_agents(self) -> List[str]:
         """Return the registered agent names preserving registration order."""
@@ -41,11 +70,51 @@ class OrchestratorService:
         record_orchestrator_decision(task.task_type, "unhandled")
         return AgentResponse(success=False, error=f"no_agent_for_{task.task_type}")
 
+    def _build_agent(self, config: AgentConfig) -> BaseAgent:
+        if isinstance(config, BaseAgent):
+            return config
+
+        if inspect.isclass(config) and issubclass(config, BaseAgent):
+            return config()
+
+        if callable(config):
+            candidate = config()
+            if not isinstance(candidate, BaseAgent):
+                raise TypeError("Agent factory did not return a BaseAgent instance")
+            return candidate
+
+        if isinstance(config, str):
+            imported = self._import_from_string(config)
+            return self._build_agent(imported)
+
+        raise TypeError(f"Unsupported agent configuration: {config!r}")
+
+    @staticmethod
+    def _import_from_string(path: str) -> object:
+        cleaned = path.strip()
+        if not cleaned:
+            raise ValueError("Empty agent configuration entry")
+
+        module_path: str
+        attr_path: str
+        if ":" in cleaned:
+            module_path, attr_path = cleaned.split(":", 1)
+        else:
+            module_path, _, attr_path = cleaned.rpartition(".")
+        if not module_path or not attr_path:
+            raise ValueError(f"Invalid agent specification: {path!r}")
+
+        module = import_module(module_path)
+        attribute: object = module
+        for part in attr_path.split("."):
+            attribute = getattr(attribute, part)
+        return attribute
+
 
 def create_default_orchestrator() -> OrchestratorService:
     """Build an orchestrator with the default agents described in the report."""
 
-    return OrchestratorService(agents=[DocumentAgent(), MediaAgent()])
+    return OrchestratorService(agents=[DocumentAgent(), MediaAgent(), CodeAgent()])
 
 
 def document_query_flow(question: str, language: str | None = None, orchestrator: OrchestratorService | None = None) -> AgentResponse:

--- a/tests/agents/test_code_agent.py
+++ b/tests/agents/test_code_agent.py
@@ -1,0 +1,102 @@
+"""Unit tests for the specialised troubleshooting code agent."""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from app.agents.base import AgentTask
+from app.agents.code import CODE_COLLECTION
+from app.agents.code_agent import CodeAgent
+
+
+class _StubCollection:
+    def __init__(self, documents: List[str] | None = None) -> None:
+        self.requests: List[tuple[list[str], int]] = []
+        self._documents = documents or ["Solución placeholder"]
+
+    def query(self, query_texts: list[str], n_results: int):
+        self.requests.append((list(query_texts), n_results))
+        return {
+            "documents": [list(self._documents)],
+            "metadatas": [[{"source": "troubleshooting.md"} for _ in self._documents]],
+        }
+
+
+def test_code_agent_returns_matches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The agent should return normalised matches from the troubleshooting collection."""
+
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_record(agent: str, task_type: str, status: str, **_: object) -> None:
+        calls.append((agent, task_type, status))
+
+    monkeypatch.setattr("app.agents.code_agent.agent.record_agent_invocation", fake_record)
+
+    collection = _StubCollection(documents=["Reiniciar el servicio", "Verificar dependencias"])
+    agent = CodeAgent(collection_resolver=lambda _: collection)
+
+    response = agent.handle(
+        AgentTask(
+            task_type="code_troubleshooting",
+            payload={"query": "Error en despliegue", "limit": 1, "language": "es"},
+        )
+    )
+
+    assert response.success is True
+    assert response.data == {
+        "collection": CODE_COLLECTION,
+        "matches": [
+            {"content": "Reiniciar el servicio", "metadata": {"source": "troubleshooting.md"}},
+            {"content": "Verificar dependencias", "metadata": {"source": "troubleshooting.md"}},
+        ],
+    }
+    assert response.metadata == {
+        "query": "Error en despliegue",
+        "match_count": 2,
+        "language": "es",
+    }
+    assert calls == [("code_agent", "code_troubleshooting", "success")]
+    assert collection.requests == [(["Error en despliegue"], 1)]
+
+
+def test_code_agent_requires_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing prompts should be reported as invalid payloads."""
+
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_record(agent: str, task_type: str, status: str, **_: object) -> None:
+        calls.append((agent, task_type, status))
+
+    monkeypatch.setattr("app.agents.code_agent.agent.record_agent_invocation", fake_record)
+
+    agent = CodeAgent(retriever=lambda *_: [])
+    response = agent.handle(AgentTask(task_type="code_troubleshooting", payload={}))
+
+    assert response.success is False
+    assert response.error == "query_missing"
+    assert calls == [("code_agent", "code_troubleshooting", "invalid")]
+
+
+def test_code_agent_handles_collection_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Failures when querying the collection should surface a controlled error."""
+
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_record(agent: str, task_type: str, status: str, **_: object) -> None:
+        calls.append((agent, task_type, status))
+
+    monkeypatch.setattr("app.agents.code_agent.agent.record_agent_invocation", fake_record)
+
+    def failing_retriever(*_: object) -> list[object]:
+        raise RuntimeError("collection offline")
+
+    agent = CodeAgent(retriever=failing_retriever)
+    response = agent.handle(
+        AgentTask(task_type="code_troubleshooting", payload={"query": "timeout"})
+    )
+
+    assert response.success is False
+    assert response.error == "code_collection_error"
+    assert calls == [("code_agent", "code_troubleshooting", "error")]

--- a/tests/agents/test_orchestrator.py
+++ b/tests/agents/test_orchestrator.py
@@ -4,9 +4,25 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from app.agents.base import AgentTask
+from app.agents.base import AgentResponse, AgentTask, BaseAgent
 from app.agents.document_agent import DocumentAgent
 from app.agents.orchestrator import OrchestratorService, document_query_flow
+
+
+class _DynamicAgent(BaseAgent):
+    def __init__(self, name: str = "dynamic_agent", handled_task: str = "dynamic_task") -> None:
+        super().__init__(name=name)
+        self._handled_task = handled_task
+
+    def can_handle(self, task: AgentTask) -> bool:
+        return task.task_type == self._handled_task
+
+    def handle(self, task: AgentTask) -> AgentResponse:
+        return AgentResponse(success=True, data={"handled_by": self.name})
+
+
+def _dynamic_factory() -> BaseAgent:
+    return _DynamicAgent(name="factory_agent", handled_task="factory_task")
 
 
 def test_orchestrator_routes_document_tasks() -> None:
@@ -57,3 +73,31 @@ def test_document_flow_helper_uses_provided_orchestrator() -> None:
     assert response.success is True
     assert response.data == {"answer": "respuesta orquestada"}
     query_function.assert_called_once_with("Explica el cubo de datos", None)
+
+
+def test_orchestrator_initialises_agents_from_config() -> None:
+    """Agent implementations can be referenced through configuration strings."""
+
+    spec = f"{__name__}:_dynamic_factory"
+    orchestrator = OrchestratorService(agent_configs=[spec])
+
+    response = orchestrator.execute(AgentTask(task_type="factory_task", payload={}))
+
+    assert response.success is True
+    assert response.data == {"handled_by": "factory_agent"}
+    assert orchestrator.available_agents() == ["factory_agent"]
+
+
+def test_orchestrator_supports_late_registration() -> None:
+    """Agents can be registered after instantiation using factories or classes."""
+
+    orchestrator = OrchestratorService()
+    agent = orchestrator.register_agent_late(lambda: _DynamicAgent(name="late_agent", handled_task="late_task"))
+
+    assert agent.name == "late_agent"
+
+    response = orchestrator.execute(AgentTask(task_type="late_task", payload={}))
+
+    assert response.success is True
+    assert response.data == {"handled_by": "late_agent"}
+    assert orchestrator.available_agents() == ["late_agent"]


### PR DESCRIPTION
## Summary
- add a dedicated `CodeAgent` that queries the troubleshooting collection with standardised telemetry-aware responses
- enrich the media agent so instruction payloads yield documented placeholder outputs
- teach the orchestrator to instantiate agents from configuration, support late registration, and ship the code agent by default
- cover the new behaviour with unit tests for the code agent and dynamic agent registration

## Testing
- pytest tests/agents


------
https://chatgpt.com/codex/tasks/task_e_68d193e4821c8320a7f184e00ce19a10