### PR TITLE
Add configurations for new Chroma domains

### DIFF
--- a/app/common/constants.py
+++ b/app/common/constants.py
@@ -86,6 +86,27 @@ CHROMA_COLLECTIONS: Mapping[str, CollectionConfig] = {
             "para enriquecer respuestas con contenido multimedia."
         ),
     ),
+    "format_specs": CollectionConfig(
+        domain="formats",
+        description=(
+            "Catálogo de convenciones y requisitos de formatos para asegurar "
+            "consistencias en entregables y conversiones."
+        ),
+    ),
+    "knowledge_guides": CollectionConfig(
+        domain="guides",
+        description=(
+            "Guías operativas y playbooks paso a paso que estructuran las "
+            "respuestas de los agentes con mejores prácticas."
+        ),
+    ),
+    "compliance_archive": CollectionConfig(
+        domain="compliance",
+        description=(
+            "Repositorio de lineamientos regulatorios y políticas internas "
+            "para respaldar respuestas con enfoque legal y normativo."
+        ),
+    ),
 }
 
 DOMAIN_TO_COLLECTION: Mapping[str, str] = {

--- a/docs/converter/chroma_collections.md
+++ b/docs/converter/chroma_collections.md
@@ -1,0 +1,27 @@
+# Colecciones de Chroma y agentes relacionados
+
+El pipeline de *Retrieval Augmented Generation* (RAG) organiza los documentos en
+colecciones temáticas dentro de ChromaDB. Cada colección mantiene una
+configuración (`CollectionConfig`) que indica el dominio semántico al que
+pertenece y permite a los agentes elegir la fuente adecuada al preparar una
+respuesta. La siguiente tabla resume el propósito de cada colección y cómo se
+relaciona con los agentes disponibles.
+
+| Colección             | Dominio      | Contenido clave                                                                                     | Ingestor principal¹                     | Agente consumidor |
+|-----------------------|--------------|------------------------------------------------------------------------------------------------------|-----------------------------------------|-------------------|
+| `conversion_rules`    | `documents`  | Manuales, guías y documentación de referencia utilizados en procesos de conversión y capacitación.  | `DocumentIngestor`                      | `DocumentAgent`   |
+| `troubleshooting`     | `code`       | Snippets de código y procedimientos para diagnosticar incidentes técnicos.                          | `CodeIngestor`                          | `DocumentAgent`   |
+| `multimedia_assets`   | `multimedia` | Transcripciones y descripciones de material audiovisual que enriquecen respuestas multimodales.     | `MultimediaIngestor`                    | `MediaAgent`      |
+| `format_specs`        | `formats`    | Convenciones, plantillas y requerimientos de formato que aseguran consistencia en entregables.       | `DocumentIngestor` (extensión planificada) | `DocumentAgent`   |
+| `knowledge_guides`    | `guides`     | Playbooks y guías operativas paso a paso para estructurar recomendaciones y mejores prácticas.       | `DocumentIngestor`                      | `DocumentAgent`   |
+| `compliance_archive`  | `compliance` | Políticas internas y lineamientos regulatorios para respaldar respuestas con enfoque legal.         | `DocumentIngestor` (curaduría legal)    | `DocumentAgent`   |
+
+¹ *Los ingestors son las clases ubicadas en `app/agents` encargadas de cargar y
+normalizar los archivos antes de almacenarlos en ChromaDB. Algunos dominios, como
+`formats`, reutilizan la infraestructura de `DocumentIngestor`, pero permiten
+filtrar y auditar el contenido con reglas específicas.*
+
+Gracias a esta clasificación, el orquestador puede enrutar tareas hacia el
+agente más apropiado (`DocumentAgent` para consultas textuales y `MediaAgent`
+para material audiovisual), mientras que las nuevas colecciones amplían la
+cobertura temática sin duplicar lógica en los agentes existentes.

--- a/tests/test_ingest_routing.py
+++ b/tests/test_ingest_routing.py
@@ -143,3 +143,21 @@ def test_files_are_routed_to_expected_collection(monkeypatch, filename, expected
         assert document.metadata["collection"] == expected_collection
         assert document.metadata["domain"] == expected_domain
         assert document.metadata["uploaded_file_name"] == filename
+
+
+@pytest.mark.parametrize(
+    "domain, expected_collection",
+    [
+        ("documents", "conversion_rules"),
+        ("code", "troubleshooting"),
+        ("multimedia", "multimedia_assets"),
+        ("formats", "format_specs"),
+        ("guides", "knowledge_guides"),
+        ("compliance", "compliance_archive"),
+    ],
+)
+def test_domain_to_collection_contains_expected_mappings(domain, expected_collection):
+    from app.common.constants import CHROMA_COLLECTIONS, DOMAIN_TO_COLLECTION
+
+    assert DOMAIN_TO_COLLECTION[domain] == expected_collection
+    assert CHROMA_COLLECTIONS[expected_collection].domain == domain


### PR DESCRIPTION
## Summary
- add CollectionConfig entries for the new formats, guides and compliance domains
- document the purpose of each collection and how agents consume them
- extend ingest routing tests to validate the new domain to collection mappings

## Testing
- pytest tests/test_ingest_routing.py

------
https://chatgpt.com/codex/tasks/task_e_68d193f6afd4832085338bb8bec71c05