### PR TITLE
Add legal compliance guardrails and sensitive citation audits

### DIFF
--- a/app/Inicio.py
+++ b/app/Inicio.py
@@ -5,9 +5,12 @@ st.set_page_config(layout='wide', page_title='Anclora AI RAG', page_icon='🤖')
 
 # Import required modules
 try:
-    from common.langchain_module import response
+    from common.langchain_module import LegalComplianceGuardError, response
+    from common.privacy import PrivacyManager
     from common.streamlit_style import hide_streamlit_style
+    from common.translations import get_text
     hide_streamlit_style()
+    _privacy_monitor = PrivacyManager()
 except ImportError as e:
     st.error(f"Error importing modules: {e}")
     st.stop()
@@ -54,7 +57,14 @@ if "messages" not in st.session_state:
 # Display chat messages from history on app rerun
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
-        st.markdown(message["content"])
+        warning_text = message.get("warning") if isinstance(message, dict) else None
+        if warning_text:
+            st.warning(warning_text)
+            content = message.get("content", "") if isinstance(message, dict) else ""
+            if content:
+                st.markdown(content)
+        else:
+            st.markdown(message["content"])
 
 # Accept user input
 if prompt := st.chat_input(chat_placeholder):
@@ -67,11 +77,48 @@ if prompt := st.chat_input(chat_placeholder):
     # Display assistant response in chat message container
     with st.chat_message("assistant"):
         try:
-            # Get response from the RAG system
             assistant_response = response(prompt, st.session_state.language)
-            st.markdown(assistant_response)
-            # Add assistant response to chat history
-            st.session_state.messages.append({"role": "assistant", "content": assistant_response})
+            inspection = _privacy_monitor.inspect_response_citations(assistant_response)
+            warning_message = None
+            if inspection.has_sensitive_citations and inspection.message_key:
+                warning_message = get_text(
+                    inspection.message_key,
+                    st.session_state.language,
+                    **dict(inspection.context),
+                )
+                if inspection.sensitive_citations:
+                    _privacy_monitor.record_sensitive_audit(
+                        response=assistant_response,
+                        citations=inspection.sensitive_citations,
+                        requested_by="streamlit_ui",
+                        query=prompt,
+                        metadata={
+                            "language": st.session_state.language,
+                            "citations": inspection.citations,
+                        },
+                    )
+
+            if warning_message:
+                st.warning(warning_message)
+                st.markdown(assistant_response)
+                st.session_state.messages.append(
+                    {
+                        "role": "assistant",
+                        "content": assistant_response,
+                        "warning": warning_message,
+                    }
+                )
+            else:
+                st.markdown(assistant_response)
+                st.session_state.messages.append(
+                    {"role": "assistant", "content": assistant_response}
+                )
+        except LegalComplianceGuardError as exc:
+            guard_message = exc.render_message(st.session_state.language)
+            st.warning(guard_message)
+            st.session_state.messages.append(
+                {"role": "assistant", "content": "", "warning": guard_message}
+            )
         except Exception as e:
             error_message = "Error procesando la solicitud" if st.session_state.language == 'es' else "Error processing request"
             st.error(f"{error_message}: {str(e)}")

--- a/app/agents/document_agent/agent.py
+++ b/app/agents/document_agent/agent.py
@@ -7,6 +7,7 @@ from typing import Callable, Optional
 
 from app.agents.base import AgentResponse, AgentTask, BaseAgent
 from app.common import langchain_module
+from app.common.langchain_module import LegalComplianceGuardError
 from common.observability import record_agent_invocation
 
 QueryFunction = Callable[[str, Optional[str]], str]
@@ -45,6 +46,16 @@ class DocumentAgent(BaseAgent):
 
         try:
             answer = self._query_function(str(question), language if language else None)
+        except LegalComplianceGuardError as exc:
+            record_agent_invocation(
+                self.name,
+                task.task_type,
+                "guardrail",
+                duration_seconds=time.perf_counter() - start_time,
+                language=language_label,
+            )
+            message = exc.render_message(language_label or "es")
+            return AgentResponse(success=False, error=message)
         except Exception as exc:  # pragma: no cover - defensive branch
             record_agent_invocation(
                 self.name,

--- a/app/common/constants.py
+++ b/app/common/constants.py
@@ -79,6 +79,13 @@ CHROMA_COLLECTIONS: Mapping[str, CollectionConfig] = {
             "dar soporte en escenarios de troubleshooting."
         ),
     ),
+    "legal_compliance": CollectionConfig(
+        domain="legal",
+        description=(
+            "Políticas legales, lineamientos regulatorios y criterios de cumplimiento "
+            "que requieren controles adicionales antes de compartirse."
+        ),
+    ),
     "multimedia_assets": CollectionConfig(
         domain="multimedia",
         description=(

--- a/app/common/i18n/en.yml
+++ b/app/common/i18n/en.yml
@@ -47,3 +47,7 @@ greeting_response: "Hello! I'm Bastet, your virtual assistant from PBC. I'm here
 no_documents: "Hi, I'm Bastet from PBC. I don't have any documents in my knowledge base yet. Please upload some documents in the 'Files' section so I can help you with specific information. In the meantime, I can share that PBC offers Software Engineering and Artificial Intelligence services."
 no_context: "No specific information was found in the knowledge base."
 processing_error: "Sorry, an error occurred while processing your query. Please try again or contact the administrator if the problem persists."
+legal_compliance_fields_not_allowed: "The request cannot be answered because unauthorized metadata ({fields}) was detected in legal compliance documents."
+legal_compliance_missing_metadata: "The retrieved legal documents are missing required information ({fields}). Please request an updated source before continuing."
+legal_compliance_policy_conflict: "Your query references multiple legal policies ({policies}). Specify the exact policy you need to continue."
+sensitive_citation_warning: "⚠️ The response includes sensitive references: {citations}. Review them carefully before sharing the answer."

--- a/app/common/i18n/es.yml
+++ b/app/common/i18n/es.yml
@@ -47,3 +47,7 @@ greeting_response: "¡Hola! Soy Bastet, tu asistente virtual de PBC. Estoy aquí
 no_documents: "Hola, soy Bastet de PBC. Actualmente no tengo documentos en mi base de conocimiento. Por favor, sube algunos documentos en la sección 'Archivos' para que pueda ayudarte con información específica. Mientras tanto, puedo contarte que PBC ofrece servicios de Ingeniería de Software e Inteligencia Artificial."
 no_context: "No se encontró información específica en la base de conocimiento."
 processing_error: "Lo siento, ocurrió un error al procesar tu consulta. Por favor, intenta nuevamente o contacta al administrador si el problema persiste."
+legal_compliance_fields_not_allowed: "No es posible responder porque se detectaron metadatos no permitidos ({fields}) en documentos de cumplimiento legal."
+legal_compliance_missing_metadata: "Los documentos legales recuperados no incluyen la información obligatoria ({fields}). Solicita una versión actualizada antes de continuar."
+legal_compliance_policy_conflict: "La consulta hace referencia a múltiples políticas legales ({policies}). Especifica cuál necesitas para continuar."
+sensitive_citation_warning: "⚠️ La respuesta incluye referencias sensibles: {citations}. Revísalas con cuidado antes de compartir la información."

--- a/app/common/langchain_module.py
+++ b/app/common/langchain_module.py
@@ -79,6 +79,7 @@ def _translate(key: str, language: str, **kwargs) -> str:
         raise RuntimeError("El sistema de traducciones no está disponible")
     return translator(key, language, **kwargs)
 
+
 try:
     from langdetect import DetectorFactory, LangDetectException, detect
 except ImportError:
@@ -93,7 +94,7 @@ import logging
 import time
 from dataclasses import dataclass
 from threading import Lock
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 # Configurar logging
 logging.basicConfig(
@@ -101,6 +102,26 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+class LegalComplianceGuardError(RuntimeError):
+    """Raised when legal compliance guardrails prevent answering a query."""
+
+    def __init__(self, message_key: str, *, context: Mapping[str, Any] | None = None) -> None:
+        super().__init__(message_key)
+        self.message_key = message_key
+        self.context: Dict[str, Any] = dict(context or {})
+
+    def render_message(self, language: str) -> str:
+        """Return a localised message describing the guardrail violation."""
+
+        formatted: Dict[str, Any] = {}
+        for key, value in self.context.items():
+            if isinstance(value, (list, tuple, set)):
+                formatted[key] = ", ".join(sorted(str(item) for item in value))
+            else:
+                formatted[key] = value
+        return _translate(self.message_key, language, **formatted)
 
 model = os.environ.get("MODEL")
 # For embeddings model, the example uses a sentence-transformers model
@@ -119,6 +140,24 @@ SUPPORTED_LANGUAGES = {"es", "en"}
 SPANISH_HINT_CHARACTERS = set("áéíóúüñÁÉÍÓÚÜÑ¿¡")
 SPANISH_HINT_WORDS = {"hola", "buenos", "buenas", "gracias", "información", "informacion"}
 ENGLISH_HINT_WORDS = {"hello", "hi", "please", "summary", "status", "report", "what", "when", "where", "why", "how", "update", "overview", "there"}
+
+LEGAL_COMPLIANCE_COLLECTION = "legal_compliance"
+LEGAL_COMPLIANCE_ALLOWED_METADATA_KEYS = frozenset(
+    {
+        "collection",
+        "distance",
+        "similarity",
+        "score",
+        "source",
+        "uploaded_file_name",
+        "policy_id",
+        "policy_version",
+        "jurisdiction",
+        "section",
+        "chunk_id",
+    }
+)
+LEGAL_COMPLIANCE_REQUIRED_METADATA_KEYS = frozenset({"policy_id", "policy_version"})
 
 
 def detect_language(text: str) -> str:
@@ -156,6 +195,67 @@ def detect_language(text: str) -> str:
         return "en"
 
     return "es"
+
+
+def _extract_legal_metadata(document: Any) -> Mapping[str, Any] | None:
+    """Return metadata for legal compliance documents if applicable."""
+
+    metadata = getattr(document, "metadata", None)
+    if not isinstance(metadata, Mapping):
+        return None
+
+    if metadata.get("collection") == LEGAL_COMPLIANCE_COLLECTION:
+        return metadata
+    return None
+
+
+def _enforce_legal_compliance_guardrails(documents: Sequence[Any]) -> None:
+    """Validate metadata constraints for legal compliance documents."""
+
+    legal_metadatas: List[Mapping[str, Any]] = []
+    for document in documents:
+        metadata = _extract_legal_metadata(document)
+        if metadata is not None:
+            legal_metadatas.append(metadata)
+
+    if not legal_metadatas:
+        return
+
+    unexpected_fields: List[str] = []
+    for metadata in legal_metadatas:
+        invalid = sorted(set(metadata) - LEGAL_COMPLIANCE_ALLOWED_METADATA_KEYS)
+        if invalid:
+            unexpected_fields.extend(str(field) for field in invalid)
+
+    if unexpected_fields:
+        raise LegalComplianceGuardError(
+            "legal_compliance_fields_not_allowed",
+            context={"fields": sorted(set(unexpected_fields))},
+        )
+
+    missing_fields: List[str] = []
+    for metadata in legal_metadatas:
+        for field in LEGAL_COMPLIANCE_REQUIRED_METADATA_KEYS:
+            value = metadata.get(field)
+            if not isinstance(value, str) or not value.strip():
+                missing_fields.append(field)
+
+    if missing_fields:
+        raise LegalComplianceGuardError(
+            "legal_compliance_missing_metadata",
+            context={"fields": sorted(set(missing_fields))},
+        )
+
+    policy_ids = {
+        str(metadata.get("policy_id")).strip()
+        for metadata in legal_metadatas
+        if str(metadata.get("policy_id"))
+    }
+    if len(policy_ids) > 1:
+        raise LegalComplianceGuardError(
+            "legal_compliance_policy_conflict",
+            context={"policies": sorted(policy_ids)},
+        )
 
 
 def parse_arguments():
@@ -494,7 +594,9 @@ def response(query: str, language: Optional[str] = None) -> str:
             ]
 
             scored_docs.sort(key=lambda item: (item[2][0], item[2][1], item[0]))
-            return [doc for _, doc, _ in scored_docs[:target_source_chunks]]
+            selected_docs = [doc for _, doc, _ in scored_docs[:target_source_chunks]]
+            _enforce_legal_compliance_guardrails(selected_docs)
+            return selected_docs
 
         # activate/deactivate the streaming StdOut callback for LLMs
         callbacks = [] if args.mute_stream else [StreamingStdOutCallbackHandler()]
@@ -529,6 +631,13 @@ def response(query: str, language: Optional[str] = None) -> str:
 
         return result
 
+    except LegalComplianceGuardError as guard_exc:
+        status = "guardrail"
+        logger.warning(
+            "Consulta bloqueada por guardrails de cumplimiento legal: %s",
+            guard_exc.message_key,
+        )
+        raise
     except Exception as e:
         error_msg = f"Error al procesar la consulta: {str(e)}"
         logger.error(error_msg)

--- a/tests/common/test_sensitive_citations.py
+++ b/tests/common/test_sensitive_citations.py
@@ -1,0 +1,52 @@
+"""Tests for privacy guardrails around sensitive citations."""
+
+from __future__ import annotations
+
+from app.common.privacy import ANONYMIZED_VALUE, PrivacyManager
+
+
+class _StubAuditLogger:
+    def __init__(self) -> None:
+        self.records: list[object] = []
+
+    def log(self, record) -> None:  # type: ignore[override]
+        self.records.append(record)
+
+
+def test_inspect_response_citations_detects_sensitive_references() -> None:
+    """Sensitive references should be detected and reported with context."""
+
+    manager = PrivacyManager(audit_logger=_StubAuditLogger())
+    response_text = (
+        "Resumen [[legal_ref: protocolo confidencial alfa]] con enlace a "
+        "[source: manual público]."
+    )
+
+    report = manager.inspect_response_citations(response_text)
+
+    assert report.has_sensitive_citations is True
+    assert report.sensitive_citations == ("protocolo confidencial alfa",)
+    assert report.message_key == "sensitive_citation_warning"
+    assert "citations" in report.context
+
+
+def test_record_sensitive_audit_registers_masked_metadata() -> None:
+    """Recording a sensitive audit should anonymise metadata before logging."""
+
+    logger = _StubAuditLogger()
+    manager = PrivacyManager(audit_logger=logger)
+
+    manager.record_sensitive_audit(
+        response="La política confidencial", 
+        citations=["policy-secret"],
+        requested_by="tester",
+        query="¿Cuál es la política?",
+        metadata={"email": "person@example.com"},
+    )
+
+    assert len(logger.records) == 1
+    record = logger.records[0]
+    assert record.status == "sensitive_response"
+    assert record.metadata["citations"] == ["policy-secret"]
+    assert record.metadata["email"] == ANONYMIZED_VALUE
+    assert record.metadata["response_preview"].startswith("La política")


### PR DESCRIPTION
## Summary
- add legal compliance collection guardrails to the LangChain response flow and surface dedicated errors when metadata violates policy
- extend the PrivacyManager with sensitive citation inspection and audit logging utilities and wire them into the API, Streamlit UI and agent guard handling
- provide translated warning/guardrail messages and new API/common tests that exercise legal queries and deletion auditing guardrails

## Testing
- `pytest tests/api tests/common tests/test_langchain_module.py tests/test_privacy.py`


------
https://chatgpt.com/codex/tasks/task_e_68d19428af28832086394d7f7698c871