### PR TITLE
Normalize metadata for Chroma ingestion

### DIFF
--- a/app/common/chroma_utils.py
+++ b/app/common/chroma_utils.py
@@ -1,10 +1,76 @@
 """Utility helpers to interact with Chroma collections."""
 from __future__ import annotations
 
-from typing import Sequence, Tuple
+import dataclasses
+import datetime as _dt
+import enum
+import logging
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePath
+from typing import Any, Tuple
 from uuid import uuid4
 
 from langchain_core.documents import Document as LangChainDocument
+
+logger = logging.getLogger(__name__)
+
+
+def _make_metadata_serializable(value: Any, *, _path: str = "metadata") -> Any:
+    """Return a JSON-serialisable representation of ``value``.
+
+    The conversion is applied recursively to mappings and sequences, normalising
+    common complex types (dataclasses, enums, paths, datetimes, callables) and
+    falling back to ``str`` for values that remain non-serialisable. Whenever a
+    value needs to be replaced by its string representation, the operation is
+    logged at ``DEBUG`` level to aid troubleshooting.
+    """
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if dataclasses.is_dataclass(value):
+        return _make_metadata_serializable(dataclasses.asdict(value), _path=_path)
+
+    if isinstance(value, enum.Enum):
+        return _make_metadata_serializable(value.value, _path=_path)
+
+    if isinstance(value, (Path, PurePath)):
+        return str(value)
+
+    if isinstance(value, (_dt.datetime, _dt.date, _dt.time)):
+        return value.isoformat()
+
+    if isinstance(value, Mapping):
+        serialised = {}
+        for key, item in value.items():
+            key_str = key if isinstance(key, str) else str(key)
+            if key_str != key:
+                logger.debug("Metadata key %r converted to string %r", key, key_str)
+            serialised[key_str] = _make_metadata_serializable(item, _path=f"{_path}.{key_str}")
+        return serialised
+
+    if isinstance(value, (list, tuple, set)):
+        return [
+            _make_metadata_serializable(item, _path=f"{_path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+
+    if callable(value):
+        replacement = getattr(value, "__qualname__", getattr(value, "__name__", repr(value)))
+        logger.debug("Metadata callable at %s replaced with %r", _path, replacement)
+        return replacement
+
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            replacement = value.hex()
+            logger.debug("Metadata bytes at %s replaced with hex string", _path)
+            return replacement
+
+    replacement = str(value)
+    logger.debug("Metadata value at %s (%s) replaced with %r", _path, type(value).__name__, replacement)
+    return replacement
 
 
 def add_langchain_documents(
@@ -22,7 +88,9 @@ def add_langchain_documents(
         return False, 0
 
     contents = [doc.page_content for doc in documents]
-    metadatas = [dict(doc.metadata or {}) for doc in documents]
+    metadatas = [
+        _make_metadata_serializable(dict(doc.metadata or {})) for doc in documents
+    ]
     vectors = embeddings.embed_documents(contents)
     ids = [f"{collection_name}-{index}-{uuid4().hex}" for index in range(len(documents))]
 
@@ -37,6 +105,4 @@ def add_langchain_documents(
 
     collection.add(ids=ids, documents=contents, embeddings=vectors, metadatas=metadatas)
     return existed, len(documents)
-
-
-__all__ = ["add_langchain_documents"]
+__all__ = ["add_langchain_documents", "_make_metadata_serializable"]

--- a/app/common/ingest_file.py
+++ b/app/common/ingest_file.py
@@ -59,7 +59,7 @@ from dataclasses import dataclass
 
 from common.chroma_db_settings import Chroma
 from common.embeddings_manager import get_embeddings_manager
-from app.common.chroma_utils import add_langchain_documents
+from app.common.chroma_utils import add_langchain_documents, _make_metadata_serializable
 
 # Custom security exception
 class SecurityError(Exception):
@@ -256,7 +256,7 @@ def _load_documents(uploaded_file, file_name: str) -> Tuple[List[Document], Base
                     "uploaded_file_name": file_name,
                 }
             )
-            document.metadata = metadata
+            document.metadata = _make_metadata_serializable(metadata)
 
         return documents, ingestor
     except Exception as e:
@@ -455,6 +455,7 @@ def process_file(uploaded_file, file_name: str) -> ProcessResult:
                     "chunk_size_config": CHUNKING_CONFIG.get(ingestor.domain, CHUNKING_CONFIG["default"])["chunk_size"],
                     "chunk_overlap_config": CHUNKING_CONFIG.get(ingestor.domain, CHUNKING_CONFIG["default"])["chunk_overlap"]
                 })
+                text.metadata = _make_metadata_serializable(text.metadata)
 
         normalized = normalize_documents_nfc(texts)
         return ProcessResult(normalized, ingestor)


### PR DESCRIPTION
## Summary
- add a recursive helper that makes document metadata JSON serialisable and logs non-serialisable replacements
- sanitise metadata before persisting to Chroma collections and while enriching ingested documents to keep the pipeline consistent

## Testing
- pytest *(fails: environment missing optional app.agents.code module and tests contain syntax/indentation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68d58e3d76e483209ae0cd53810962c2