### PR TITLE
Refine ingestion summaries and expose job-friendly payloads

### DIFF
--- a/app/common/embeddings_manager.py
+++ b/app/common/embeddings_manager.py
@@ -148,7 +148,10 @@ class EmbeddingsManager:
                     langchain_module, "HuggingFaceEmbeddings", embedding_cls
                 )
             if embedding_cls is None or not callable(embedding_cls):
-                from langchain_huggingface import HuggingFaceEmbeddings as _HF
+                try:
+                    from langchain_huggingface import HuggingFaceEmbeddings as _HF
+                except ImportError:
+                    from langchain_community.embeddings import HuggingFaceEmbeddings as _HF  # type: ignore[assignment]
 
                 embedding_cls = _HF
                 globals()["HuggingFaceEmbeddings"] = _HF

--- a/app/ingestion/file_processor.py
+++ b/app/ingestion/file_processor.py
@@ -63,10 +63,34 @@ class FileProcessor:
 
         success = bool(result.get("success")) if isinstance(result, dict) else False
         error = result.get("error") if isinstance(result, dict) else None
+        summary = result.get("summary") if isinstance(result, dict) else None
+        message = result.get("message") if isinstance(result, dict) else None
+        domain = result.get("domain") if isinstance(result, dict) else None
+        collection = result.get("collection") if isinstance(result, dict) else None
+        duplicate = result.get("duplicate") if isinstance(result, dict) else None
+
+        sanitized_result = None
+        if isinstance(result, dict):
+            sanitized_result = {
+                key: value
+                for key, value in (
+                    ("message", message),
+                    ("domain", domain),
+                    ("collection", collection),
+                    ("summary", summary),
+                    ("duplicate", duplicate),
+                )
+                if value is not None
+            }
+            if not sanitized_result:
+                sanitized_result = None
+
         payload = {
             "file_name": file_name,
             "success": success,
-            "result": result,
+            "summary": summary,
+            "message": message,
+            "result": sanitized_result,
             "error": error,
             "metadata": metadata,
         }

--- a/docs/Sistema de Ingesta Avanzado para Anclora RAG.md
+++ b/docs/Sistema de Ingesta Avanzado para Anclora RAG.md
@@ -199,8 +199,21 @@ class AdvancedIngestionSystem:
         
         finally:
             job.end_time = datetime.now()
-            
+
         return job
+
+### Formato de `job.files`
+
+Cada elemento agregado a `job.files` incluye un resumen serializable en la clave `summary` para evitar exponer objetos complejos como `ProcessResult`. Este resumen contiene:
+
+- `collection`: nombre de la colección en Chroma asociada al archivo ingerido.
+- `domain`: dominio que determinó el esquema de chunking aplicado.
+- `chunk_count`: cantidad total de chunks generados durante la normalización.
+- `total_characters`: suma de caracteres en todos los chunks procesados.
+- `duplicate`: indicador booleano que permite detectar rápidamente si el archivo fue descartado por estar repetido.
+- `warnings`: lista opcional de advertencias recogidas durante la conversión (p. ej., problemas puntuales de formato).
+
+Los integradores que necesiten detalles adicionales pueden consultar el mensaje principal (`message`) y la metadata complementaria disponible en el payload del archivo. Si se requiere reconstruir el resultado completo, es posible reingestar el archivo utilizando los helpers tradicionales del módulo `ingest_file`, que continúan devolviendo `ProcessResult` en memoria antes de su serialización.
     
     async def ingest_folder(
         self,


### PR DESCRIPTION
## Summary
- add a `ProcessResult.to_summary` helper and have the ingestion pipeline return serialisable summaries instead of the raw objects
- harden the ingestion fallbacks (text splitter kwargs, embeddings factory, storage without embed_documents) and ensure file processors surface the new summary payload
- extend the advanced ingestion UI and docs to explain and display the new per-file summaries for completed jobs

## Testing
- pytest tests/converter/test_ingest_pipeline.py::test_ingest_file_adds_documents_with_metadata


------
https://chatgpt.com/codex/tasks/task_e_68d58e428c3883208ec3507a03a774be